### PR TITLE
This check fails - it should be marked as required

### DIFF
--- a/checks/nonprintable.php
+++ b/checks/nonprintable.php
@@ -13,7 +13,7 @@ class NonPrintableCheck implements themecheck {
 			if ( preg_match('/[\x00-\x08\x0B-\x0C\x0E-\x1F\x80-\xFF]/', $content, $matches ) ) {
 				$filename = tc_filename( $name );
 				$non_print = tc_preg( '/[\x00-\x08\x0B-\x0C\x0E-\x1F\x80-\xFF]/', $name );
-				$this->error[] = sprintf('<span class="tc-lead tc-info">'.__('INFO','theme-check').'</span>: '.__('Non-printable characters were found in the %1$s file. You may want to check this file for errors.%2$s', 'theme-check'), '<strong>' . $filename . '</strong>', $non_print);
+				$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Non-printable characters were found in the %1$s file. You may want to check this file for errors.%2$s', 'theme-check'), '<strong>' . $filename . '</strong>', $non_print);
 			}
 		}
 


### PR DESCRIPTION
As `$ret` is set to `true` this will fail the check. The text should show that too by marking as required and not just info.