### PR TITLE
Change readme.txt to must have

### DIFF
--- a/checks/filenames.php
+++ b/checks/filenames.php
@@ -33,8 +33,8 @@ class File_Checks implements themecheck {
 				'\.lubith'				=> __( 'Lubith theme generator file', 'theme-check' ),
 				);
 
-		$musthave = array( 'index.php', 'style.css' );
-		$rechave = array( 'readme.txt' => __( 'Please see <a href="https://codex.wordpress.org/Theme_Review#Theme_Documentation">Theme_Documentation</a> for more information.', 'theme-check' ) );
+		$musthave = array( 'index.php', 'style.css', 'readme.txt' );
+		$rechave = array();
 
 		checkcount();
 
@@ -48,7 +48,7 @@ class File_Checks implements themecheck {
 
 		foreach( $musthave as $file ) {
 			if ( !in_array( $file, $filenames ) ) {
-				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('Could not find the file %s in the theme.', 'theme-check'), '<strong>' . $file . '</strong>' );
+				$this->error[] = sprintf('<span class="tc-lead tc-required">'.__('REQUIRED','theme-check').'</span>: '.__('Could not find the file %s in the theme.', 'theme-check'), '<strong>' . $file . '</strong>' );
 				$ret = false;
 			}
 		}


### PR DESCRIPTION
Change the must have to REQUIRED.
Move readme.txt from Recommended to Required.

The readme.txt file is required as of October 25th, 2018.
The link to Required is https://make.wordpress.org/themes/handbook/review/required/#readme-txt-file