### PR TITLE
Fixes a deprecation notice on PHP 7.4

### DIFF
--- a/checks/filenames.php
+++ b/checks/filenames.php
@@ -40,7 +40,7 @@ class File_Checks implements themecheck {
 
 		foreach( $blacklist as $file => $reason ) {
 			if ( $filename = preg_grep( '/' . $file . '/', $filenames ) ) {
-				$error = implode( array_unique( $filename ), ' ' );
+				$error = implode( ' ', array_unique( $filename ) );
 				$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('%1$s %2$s found.', 'theme-check'), '<strong>' . $error . '</strong>', $reason) ;
 				$ret = false;
 			}

--- a/checks/included-plugins.php
+++ b/checks/included-plugins.php
@@ -19,7 +19,7 @@ class IncludedPlugins implements themecheck {
 
 		foreach ( $blacklist as $file => $reason ) {
 			if ( $filename = preg_grep( '/' . $file . '/', $filenames ) ) {
-				$error = implode( array_unique( $filename ), ' ' );
+				$error = implode( ' ', array_unique( $filename ) );
 				$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED','theme-check' ) . '</span>: ' . __( '<strong>Zip file found.</strong> Plugins are not allowed in themes. The zip file found was <em>%s</em>.', 'theme-check' ), $error );
 				$ret = false;
 			}

--- a/main.php
+++ b/main.php
@@ -52,7 +52,7 @@ function check_main( $theme ) {
 		echo ( !empty( $data[ 'URI' ] ) ) ? '<p><label>' . __( 'Theme URI', 'theme-check' ) . '</label><span class="info"><a href="' . $data[ 'URI' ] . '">' . $data[ 'URI' ] . '</a>' . '</span></p>' : '';
 		echo ( !empty( $data[ 'License' ] ) ) ? '<p><label>' . __( 'License', 'theme-check' ) . '</label><span class="info">' . $data[ 'License' ] . '</span></p>' : '';
 		echo ( !empty( $data[ 'License URI' ] ) ) ? '<p><label>' . __( 'License URI', 'theme-check' ) . '</label><span class="info">' . $data[ 'License URI' ] . '</span></p>' : '';
-		echo ( !empty( $data[ 'Tags' ] ) ) ? '<p><label>' . __( 'Tags', 'theme-check' ) . '</label><span class="info">' . implode( $data[ 'Tags' ], ', ') . '</span></p>' : '';
+		echo ( !empty( $data[ 'Tags' ] ) ) ? '<p><label>' . __( 'Tags', 'theme-check' ) . '</label><span class="info">' . implode( ', ', $data[ 'Tags' ] ) . '</span></p>' : '';
 		echo ( !empty( $data[ 'Description' ] ) ) ? '<p><label>' . __( 'Description', 'theme-check' ) . '</label><span class="info">' . $data[ 'Description' ] . '</span></p>' : '';
 
 		if ( $data[ 'Template' ] ) {


### PR DESCRIPTION
It fixes the following notice, 'Deprecated: implode(): Passing glue string after array is deprecated. Swap the parameters in D:\root\test\wp3\wp-content\plugins\theme-check\main.php on line 55'.