### PR TITLE
Plugin Territory - Actions & Filters

### DIFF
--- a/checks/plugin-territory.php
+++ b/checks/plugin-territory.php
@@ -34,6 +34,28 @@ class Plugin_Territory implements themecheck {
 			$ret = false;
 		}
 
+		// Hooks (actions & filters) that are required to be removed from the theme.
+		$forbidden_hooks = array(
+			'filter' => array(
+				'mime_types',
+				'upload_mimes',
+				'user_contactmethods'
+			),
+			'action' => array(
+				'wp_dashboard_setup'
+			)
+		);
+
+		foreach ( $forbidden_hooks as $type => $hooks ) {
+			foreach ( $hooks as $hook ) {
+				checkcount();
+				if ( preg_match( '/[\s?]add_' . $type . '\s*\(\s*([\'"])' . $hook . '([\'"])\s*,/', $php ) ) {
+					$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . sprintf( __( 'The theme uses the %1$s %2$s, which is plugin-territory functionality.', 'theme-check' ), '<strong>' . esc_html( $hook ) . '</strong>', esc_html( $type ) );
+					$ret = false;
+				}
+			}
+		}
+
 		return $ret;
 	}
 

--- a/checks/plugin-territory.php
+++ b/checks/plugin-territory.php
@@ -16,6 +16,7 @@ class Plugin_Territory implements themecheck {
 		$forbidden_functions = array(
 			'register_post_type',
 			'register_taxonomy',
+			'wp_add_dashboard_widget'
 		);
 
 		foreach ( $forbidden_functions as $function ) {


### PR DESCRIPTION
This PR adds a few actions and filters I recently encountered in a few of my reviews. 

Filters: 
* `mime_types`, `upload_mimes`
* `user_contactmethods`

Actions:
* `wp_dashboard_setup`, ([example](https://themes.trac.wordpress.org/browser/business-lander/1.1.11/inc/dashboard-widget.php#L12))

Can be tested by adding this in a theme:
```
add_action( 'wp_dashboard_setup', function() {} );
add_filter(  "upload_mimes" ,  function( $mimes ) { return $mimes; } );
add_filter ('user_contactmethods',function( $methods ) { return $methods; } );
```