### PR TITLE
Add check for disallowed theme names

### DIFF
--- a/checks/themename.php
+++ b/checks/themename.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Check for prohibited words and theme names.
+ */
+
+
+class ThemeNameCheck implements themecheck {
+	protected $error = array();
+
+	function check( $php_files, $css_files, $other_files ) {
+
+		checkcount();
+		$ret = true;
+		global $themename;
+
+		/* Get the author name from style.css. */
+		foreach ( $css_files as $cssfile => $content ) {
+			if ( basename( $cssfile ) === 'style.css' ) {
+				$data = get_theme_data_from_contents( $content );
+			}
+		}
+
+		/* Remove the link added by get_theme_data_from_contents */
+		$author = wp_strip_all_tags( $data['Author'] );
+
+		/* If the author is not the WordPress team, check for prohibited names */
+		if ( 'the WordPress team' !== $author ) {
+
+			$blacklist = array( 'twentyten', 'twentyeleven', 'twentytwelve', 'twentythirteen', 'twentyfourteen', 'twentyfifteen',
+			'twentysixteen', 'twentyseventeen', 'twentyeighteen', 'twentynineteen', 'twentytwenty', 'twentytwentyone',
+			'twentytwentytwo', 'twentytwentythree', 'twentytwentyfour', 'twentytwentyfive', 'twentytwentysix',
+			'twentytwentyseven', 'twentytwentyeight', 'twentytwentynine', 'twentythirty'
+			);
+
+			foreach ( $blacklist as $key ) {
+				if ( stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), $key ) !== false ) {
+					$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . sprintf( __( 'Theme names in the Twenty* series are reserved for default themes. Found %1$s.', 'theme-check' ), '<strong>' . $key . '</strong>' );
+					$ret = false;
+				}
+			}
+		}
+
+		/* Check for prohibited words. */
+		if ( stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), 'wordpress' ) !== false
+			|| stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), 'theme' ) !== false ) {
+			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Theme names should not contain the words theme or WordPress.', 'theme-check' );
+			$ret = false;
+		}
+
+		return $ret;
+	}
+
+	function getError() { return $this->error; }
+}
+
+$themechecks[] = new ThemeNameCheck();

--- a/checks/themename.php
+++ b/checks/themename.php
@@ -1,12 +1,29 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName
 /**
  * Check for prohibited words and theme names.
+ *
+ * @link https://make.wordpress.org/themes/handbook/review/required/#naming
  */
 
+/**
+ * Check for the words "theme", "WordPress" and the official theme names.
+ */
 class ThemeNameCheck implements themecheck {
+	/**
+	 * Error messages, warnings and info notices.
+	 *
+	 * @var array $error
+	 */
 	protected $error = array();
 
-	function check( $php_files, $css_files, $other_files ) {
+	/**
+	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
+	 *
+	 * @param array $php_files File paths and content for PHP files.
+	 * @param array $css_files File paths and content for CSS files.
+	 * @param array $other_files Folder names, file paths and content for other files.
+	 */
+	public function check( $php_files, $css_files, $other_files ) {
 
 		$ret = true;
 		global $themename;
@@ -14,14 +31,12 @@ class ThemeNameCheck implements themecheck {
 
 		/* Remove the link added by get_theme_data_from_contents. */
 		$author = wp_strip_all_tags( $data['Author'] );
-
-		/* Get the name, as added in style.css */
-		$title = $data[ 'Title' ];
+		/* Get the name, as added in style.css but lower case. */
+		$title = strtolower( $data['Title'] );
 
 		checkcount();
 		/* If the author is not the WordPress team, check for prohibited names. */
 		if ( 'the WordPress team' !== $author ) {
-
 			$blacklist = array( 'twentyten', 'twentyeleven', 'twentytwelve', 'twentythirteen', 'twentyfourteen', 'twentyfifteen',
 			'twentysixteen', 'twentyseventeen', 'twentyeighteen', 'twentynineteen', 'twentytwenty', 'twentytwentyone',
 			'twentytwentytwo', 'twentytwentythree', 'twentytwentyfour', 'twentytwentyfive', 'twentytwentysix',
@@ -37,22 +52,29 @@ class ThemeNameCheck implements themecheck {
 
 		checkcount();
 		/* Check for prohibited words in the folder name. */
-		if ( stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), 'wordpress' ) !== false
+		if ( stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), 'wordpress' ) !== false // phpcs:ignore WordPress.WP.CapitalPDangit
 			|| stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), 'theme' ) !== false ) {
-			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Theme names should not contain the words theme or WordPress.', 'theme-check' );
+			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Theme folder names must not contain the words <strong>theme</strong> or <strong>WordPress</strong>.', 'theme-check' );
 		}
 
 		checkcount();
 		/* Check for prohibited words in style.css. */
-		if ( stripos( strtolower( preg_replace( '/[^a-z]/', '', $title ) ), 'wordpress' ) !== false
-			|| stripos( strtolower( preg_replace( '/[^a-z]/', '', $title ) ), 'theme' ) !== false ) {
-			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Theme names should not contain the words theme or WordPress.', 'theme-check' );
+		if ( stripos( preg_replace( '/[^a-z]/', '', $title ), 'wordpress' ) !== false // phpcs:ignore WordPress.WP.CapitalPDangit
+			|| stripos( preg_replace( '/[^a-z]/', '', $title ), 'theme' ) !== false ) {
+			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Theme names must not contain the words <strong>theme</strong> or <strong>WordPress</strong>.', 'theme-check' );
 		}
 
 		return $ret;
 	}
 
-	function getError() { return $this->error; }
+	/**
+	 * Get error messages from the checks.
+	 *
+	 * @return array Error message.
+	 */
+	public function getError() {
+		return $this->error;
+	}
 }
 
 $themechecks[] = new ThemeNameCheck();

--- a/checks/themename.php
+++ b/checks/themename.php
@@ -8,7 +8,6 @@ class ThemeNameCheck implements themecheck {
 
 	function check( $php_files, $css_files, $other_files ) {
 
-		checkcount();
 		$ret = true;
 		global $themename;
 		global $data;
@@ -16,6 +15,10 @@ class ThemeNameCheck implements themecheck {
 		/* Remove the link added by get_theme_data_from_contents. */
 		$author = wp_strip_all_tags( $data['Author'] );
 
+		/* Get the name, as added in style.css */
+		$title = $data[ 'Title' ];
+
+		checkcount();
 		/* If the author is not the WordPress team, check for prohibited names. */
 		if ( 'the WordPress team' !== $author ) {
 
@@ -25,19 +28,25 @@ class ThemeNameCheck implements themecheck {
 			'twentytwentyseven', 'twentytwentyeight', 'twentytwentynine', 'twentythirty'
 			);
 
-			foreach ( $blacklist as $key ) {
-				if ( stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), $key ) !== false ) {
-					$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . sprintf( __( 'Theme names in the Twenty* series are reserved for default themes. Found %1$s.', 'theme-check' ), '<strong>' . $key . '</strong>' );
-					$ret = false;
+			foreach ( $blacklist as $blacklisted_theme_name ) {
+				if ( stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), $blacklisted_theme_name ) !== false ) {
+					$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . sprintf( __( 'Theme names in the Twenty* series are reserved for default themes. Found %1$s.', 'theme-check' ), '<strong>' . $blacklisted_theme_name . '</strong>' );
 				}
 			}
 		}
 
-		/* Check for prohibited words. */
+		checkcount();
+		/* Check for prohibited words in the folder name. */
 		if ( stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), 'wordpress' ) !== false
 			|| stripos( strtolower( preg_replace( '/[^a-z]/', '', $themename ) ), 'theme' ) !== false ) {
 			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Theme names should not contain the words theme or WordPress.', 'theme-check' );
-			$ret = false;
+		}
+
+		checkcount();
+		/* Check for prohibited words in style.css. */
+		if ( stripos( strtolower( preg_replace( '/[^a-z]/', '', $title ) ), 'wordpress' ) !== false
+			|| stripos( strtolower( preg_replace( '/[^a-z]/', '', $title ) ), 'theme' ) !== false ) {
+			$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Theme names should not contain the words theme or WordPress.', 'theme-check' );
 		}
 
 		return $ret;

--- a/checks/themename.php
+++ b/checks/themename.php
@@ -3,7 +3,6 @@
  * Check for prohibited words and theme names.
  */
 
-
 class ThemeNameCheck implements themecheck {
 	protected $error = array();
 
@@ -12,18 +11,12 @@ class ThemeNameCheck implements themecheck {
 		checkcount();
 		$ret = true;
 		global $themename;
+		global $data;
 
-		/* Get the author name from style.css. */
-		foreach ( $css_files as $cssfile => $content ) {
-			if ( basename( $cssfile ) === 'style.css' ) {
-				$data = get_theme_data_from_contents( $content );
-			}
-		}
-
-		/* Remove the link added by get_theme_data_from_contents */
+		/* Remove the link added by get_theme_data_from_contents. */
 		$author = wp_strip_all_tags( $data['Author'] );
 
-		/* If the author is not the WordPress team, check for prohibited names */
+		/* If the author is not the WordPress team, check for prohibited names. */
 		if ( 'the WordPress team' !== $author ) {
 
 			$blacklist = array( 'twentyten', 'twentyeleven', 'twentytwelve', 'twentythirteen', 'twentyfourteen', 'twentyfifteen',


### PR DESCRIPTION
Solves #106 

-Now allows exceptions for existing themes with the words theme and WordPress in the names.

