### PR TITLE
Warn for hiding the adminbar

### DIFF
--- a/checks/adminbar.php
+++ b/checks/adminbar.php
@@ -6,11 +6,12 @@ class NoHiddenAdminBar implements themecheck {
 	protected $error = array();
 
 	function check( $php_files, $css_files, $other_files ) {
-		$ret = true;
-		checkcount();
+		$ret      = true;
+
 		$php_regex = "/(add_filter(\s*)\((\s*)(\"|')show_admin_bar(\"|')(\s*)(.*))|(([^\S])show_admin_bar(\s*)\((.*))/";
 		$css_regex = "/(#wpadminbar)/";
 
+		checkcount();
 		// Check php files for filter show_admin_bar, show_admin_bar_front, and show_admin_bar().
 		foreach ( $php_files as $file_path => $file_content ) {
 
@@ -26,12 +27,18 @@ class NoHiddenAdminBar implements themecheck {
 			}
 		}
 
+		checkcount();
 		// Check CSS Files for #wpadminbar.
 		foreach ( $css_files as $file_path => $file_content ) {
 
 			$filename = tc_filename( $file_path );
 			$error    = '/#wpadminbar/';
-			$grep     = tc_preg( $error, $file_path );
+			// Don't print minified files.
+			if ( strpos( $filename, '.min.' ) === false ) {
+				$grep = tc_preg( $error, $file_path );
+			} else {
+				$grep = '';
+			}
 
 			if ( preg_match( $css_regex, $file_content, $matches ) ) {
 				$this->error[] = sprintf( '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . __( 'The theme is using `#wpadminbar` in %1$s. Hiding the admin bar is not allowed. This warning must be manually checked.', 'theme-check' ),
@@ -39,7 +46,7 @@ class NoHiddenAdminBar implements themecheck {
 			}
 		}
 
-	return $ret;
+		return $ret;
 	}
 
 	function getError() { return $this->error; }

--- a/checks/adminbar.php
+++ b/checks/adminbar.php
@@ -1,41 +1,48 @@
 <?php
 /**
- * This checks, if the admin bar gets hidden by the theme
+ * This checks if the admin bar gets hidden by the theme.
  **/
 class NoHiddenAdminBar implements themecheck {
 	protected $error = array();
 
-		function check( $php_files, $css_files, $other_files ) {
-			$ret = true;
-			checkcount();
-			$php_regex = "/(add_filter(\s*)\((\s*)(\"|')show_admin_bar(\"|')(\s*)(.*))|(([^\S])show_admin_bar(\s*)\((.*))/";
-			$css_regex = "/(#wpadminbar)/";
+	function check( $php_files, $css_files, $other_files ) {
+		$ret = true;
+		checkcount();
+		$php_regex = "/(add_filter(\s*)\((\s*)(\"|')show_admin_bar(\"|')(\s*)(.*))|(([^\S])show_admin_bar(\s*)\((.*))/";
+		$css_regex = "/(#wpadminbar)/";
 
-			//Check php files for filter show_admin_bar and show_admin_bar()
-			foreach ( $php_files as $file_path => $file_content ) {
+		// Check php files for filter show_admin_bar, show_admin_bar_front, and show_admin_bar().
+		foreach ( $php_files as $file_path => $file_content ) {
 
-				$filename = tc_filename( $file_path );
+			$filename = tc_filename( $file_path );
 
-				if ( preg_match( $php_regex, $file_content, $matches ) ) {
-					$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check').'</span>: ' . __( 'You are not allowed to hide the admin bar.', 'theme-check' ), 
-						'<strong>' . $filename . '</strong>');	
-					$ret = false;			
-				}
+			if ( preg_match( $php_regex, $file_content, $matches ) ) {
+
+				$error = '/show_admin_bar/';
+				$grep  = tc_preg( $error, $file_path );
+
+				$this->error[] = sprintf( '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . __( '%1$s Themes are not allowed to hide the admin bar. This warning must be manually checked.', 'theme-check' ),
+				'<strong>' . $filename . '</strong>' ) . $grep;
 			}
+		}
 
-			//Check CSS Files for #wpadminbar
-			foreach ( $css_files as $file_path => $file_content ) {
+		// Check CSS Files for #wpadminbar.
+		foreach ( $css_files as $file_path => $file_content ) {
 
-				$filename = tc_filename( $file_path );
+			$filename = tc_filename( $file_path );
+			$error    = '/#wpadminbar/';
+			$grep     = tc_preg( $error, $file_path );
 
-				if ( preg_match( $css_regex, $file_content, $matches ) ) {
-					$this->error[] = sprintf( '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check').'</span>: ' . __( 'The theme is using `#wpadminbar`. Hiding the admin bar is not allowed.', 'theme-check' ), 
-						'<strong>' . $filename . '</strong>');		
-				}
+			if ( preg_match( $css_regex, $file_content, $matches ) ) {
+				$this->error[] = sprintf( '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . __( 'The theme is using `#wpadminbar` in %1$s. Hiding the admin bar is not allowed. This warning must be manually checked.', 'theme-check' ),
+				'<strong>' . $filename . '</strong>' ) . $grep;
 			}
-		return $ret;
+		}
+
+	return $ret;
 	}
 
 	function getError() { return $this->error; }
 }
-$themechecks[] = new NoHiddenAdminBar;
+
+$themechecks[] = new NoHiddenAdminBar();


### PR DESCRIPTION
Warn for hiding the adminbar. Also adds file names and line numbers.
Setting this to a warning instead of required lets theme authors check if the admin bar is visible or not
(Useful for example to change position of elements below the bar).
Returns true, so that upload is not blocked.

Solves #163