### PR TITLE
Update navmenu.php

### DIFF
--- a/checks/navmenu.php
+++ b/checks/navmenu.php
@@ -5,9 +5,10 @@ class NavMenuCheck implements themecheck {
 
 	function check( $php_files, $css_files, $other_files ) {
 
-		$ret = true;
+		$ret        = true;
+		$name_check = false;
 
-		$php = implode( ' ', $php_files );
+		$php        = implode( ' ', $php_files );
 
 		checkcount();
 		if ( strpos( $php, 'nav_menu' ) === false ) {
@@ -25,30 +26,22 @@ class NavMenuCheck implements themecheck {
 		foreach ( $php_files as $file_path => $file_content ) {
 			$filename = tc_filename( $file_path );
 
-			// We are checking for wp_nav_menu( specifically, to allow wp_nav_menu in filters etc.
+			// We are checking for wp_nav_menu( specifically, to allow wp_nav_menu  and wp_nav_menu_item in filters etc.
 			if ( strpos( $file_content, 'wp_nav_menu(' ) !== false ) {
 				$menu_part = explode( 'wp_nav_menu(', $file_content );
 				$menu_part = explode( ';', $menu_part[1] );
 
-				// If there is a menu, check for a menu name, which is not allowed.
-				checkcount();
-				if ( preg_match( '/("|\')menu("|\').*?=>/', $menu_part[0] ) ) {
-					$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . sprintf( __( 'A menu name is being used for a menu in %1$s. By using menu name, the menu would be required to have the exact same name in the WordPress admin area. Use a theme_location instead.', 'theme-check' ),
-						'<strong>' . $filename . '</strong>'
-					);
-					$ret           = false;
-				}
-
 				// If there is a menu, check for a theme location, which is required.
 				// Check if the arguments are placed outside wp_nav_menu.
 				checkcount();
-				if ( preg_match( '/\$/', $menu_part[0] ) && strpos( $menu_part[0], 'theme_location' ) === false ) {
-					$menu_args = explode( '$', $menu_part[0], 1 );
-					$name      = explode( ')', $menu_args[0] );
+				if ( strpos( $menu_part[0], '$' ) !== false && strpos( $menu_part[0], 'theme_location' ) === false ) {
+					$menu_args     = explode( '$', $menu_part[0], 1 );
+					$name          = explode( ')', $menu_args[0] );
 					$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . sprintf( __( 'A menu without a theme_location was found in %1$s. %2$s is used inside wp_nav_menu(). You must manually check if the theme_location is included.', 'theme-check' ),
 						'<strong>' . $filename . '</strong>',
 						'<strong>' . $name[0] . '</strong>'
 					);
+					$name_check    = true;
 				} else {
 					checkcount();
 					if ( strpos( $menu_part[0], 'theme_location' ) === false ) {
@@ -56,7 +49,17 @@ class NavMenuCheck implements themecheck {
 							'<strong>' . $filename . '</strong>'
 						);
 						$ret           = false;
+						$name_check    = true;
 					}
+				}
+
+				// We only need to warn for the menu name if theme location is not set.
+				checkcount();
+				if ( $name_check === true && preg_match( '/("|\')menu("|\').*?=>/', $menu_part[0] ) ) {
+					$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . sprintf( __( 'A menu name is being used for a menu in %1$s. By using menu name, the menu would be required to have the exact same name in the WordPress admin area. Use a theme_location instead.', 'theme-check' ),
+						'<strong>' . $filename . '</strong>'
+					);
+					$ret           = false;
 				}
 			}
 		}

--- a/checks/navmenu.php
+++ b/checks/navmenu.php
@@ -39,7 +39,7 @@ class NavMenuCheck implements themecheck {
 					$name          = explode( ')', $menu_args[0] );
 					$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . sprintf( __( 'A menu without a theme_location was found in %1$s. %2$s is used inside wp_nav_menu(). You must manually check if the theme_location is included.', 'theme-check' ),
 						'<strong>' . $filename . '</strong>',
-						'<strong>' . $name[0] . '</strong>'
+						'<code>' . $name[0] . '</code>'
 					);
 					$name_check    = true;
 				} else {


### PR DESCRIPTION
Fixes an issue where a present but empty menu name would cause a "required" message to show.

-Only check for a menu name if there is no theme location.

-Replace one preg_match with strpos for speed.