### PR TITLE
Fix for the parse error in plugin-territory.php

### DIFF
--- a/checks/plugin-territory.php
+++ b/checks/plugin-territory.php
@@ -113,7 +113,7 @@ class Plugin_Territory implements themecheck {
 				if ( preg_match( '/[\s?]remove_action\s*\(\s*([\'"])' . $hook . '([\'"])\s*,\s*([\'"])' . $function . '([\'"])/', $php ) ) {
 					$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . sprintf( __( 'The theme uses <strong>remove_action %1$s %2$s</strong>, which is plugin-territory functionality.', 'theme-check' ),
 						esc_html( $hook ),
-						esc_html( $function ),
+						esc_html( $function )
 					);
 					$ret           = false;
 				}


### PR DESCRIPTION
Fix for:
`Parse error: syntax error, unexpected ')' in \wp-content\plugins\theme-check\checks\plugin-territory.php on line 117`