### PR TITLE
Add filters to skip checking other files in common dev directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,13 @@ comments, or feedback:[[br]]
 
 If **either** of these two vars are defined a new trac tickbox will appear next to the *Check it!* button.
 
+If you want to exclude checking other files in development directories return `true` for the filter `tc_skip_development_directories`.
+
+```
+add_filter( 'tc_skip_development_directories', '__return_true' );
+```
+
+To add more directories to the paths where other files are excluded then add them to the array through the `tc_common_dev_directories` filter.
+
 ## Contributors
 Otto42, pross, The theme review team

--- a/main.php
+++ b/main.php
@@ -31,6 +31,13 @@ function check_main( $theme ) {
 			} elseif ( substr( $filename, -4 ) === '.css' && ! is_dir( $filename ) ) {
 				$css[ $filename ] = file_get_contents( $filename );
 			} else {
+				// In local development it might be useful to skip other files
+				// (non .php or .css files) in dev directories.
+				if ( apply_filters( 'tc_skip_development_directories', false ) ) {
+					if ( tc_is_other_file_in_dev_directory( $filename ) ) {
+						continue;
+					}
+				}
 				$other[ $filename ] = ( ! is_dir( $filename ) ) ? file_get_contents( $filename ) : '';
 			}
 		}
@@ -223,4 +230,30 @@ function tc_form() {
 	echo '<input name="s_info" type="checkbox" /> ' . esc_html__( 'Suppress INFO.', 'theme-check' );
 	wp_nonce_field( 'themecheck-nonce' );
 	echo '</form>';
+}
+
+/**
+ * Used to allow some directories to be skipped during development.
+ *
+ * @param  string  $filename a filename/path
+ * @return boolean
+ */
+function tc_is_other_file_in_dev_directory( $filename ) {
+	$skip     = false;
+	// Filterable List of dirs that you may want to skip other files in during
+	// development.
+	$dev_dirs = apply_filters(
+		'tc_common_dev_directories',
+		array(
+			'node_modules',
+			'vendor',
+		)
+	);
+	foreach ( $dev_dirs as $dev_dir ) {
+		if ( strpos( $filename, $dev_dir ) ) {
+			$skip = true;
+			break;
+		}
+	}
+	return $skip;
 }


### PR DESCRIPTION
This adds a pair of filters that can be used to exclude checking of other files (non `.php` and `.css` files) during local development. It helps prevent fatal from memory exhaustion caused when the `node_modules` or `vendors` directory has lots of developer dependancies.

`tc_skip_development_directories`
`tc_common_dev_directories`

Fixes: #204 #217 