### PR TITLE
add new allowable 'block-patterns'  and 'full-site-editing' tags

### DIFF
--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -64,65 +64,65 @@ class Style_Tags implements themecheck {
 
 	function getError() { return $this->error; }
 
-    /**
-     * Get full list of allowed tags - including subject tags.
-     *
-     * @return array
-     */
+	/**
+	 * Get full list of allowed tags - including subject tags.
+	 *
+	 * @return array
+	 */
 	public static function get_allowed_tags() {
 		$allowed_tags = array(
-            'grid-layout',
-            'one-column',
-            'two-columns',
-            'three-columns',
-            'four-columns',
-            'left-sidebar',
-            'right-sidebar',
-            'wide-blocks',
-            'flexible-header',
-            'footer-widgets',
-            'accessibility-ready',
-            'block-patterns',
-            'block-styles',
-            'buddypress',
-            'custom-background',
-            'custom-colors',
-            'custom-header',
-            'custom-logo',
-            'custom-menu',
-            'editor-style',
-            'featured-image-header',
-            'featured-images',
-            'front-page-post-form',
-            'full-width-template',
-            'microformats',
-            'post-formats',
-            'rtl-language-support',
-            'sticky-post',
-            'theme-options',
-            'threaded-comments',
-            'translation-ready',
-        );
-        return array_merge( $allowed_tags, self::get_subject_tags() );
+			'grid-layout',
+			'one-column',
+			'two-columns',
+			'three-columns',
+			'four-columns',
+			'left-sidebar',
+			'right-sidebar',
+			'wide-blocks',
+			'flexible-header',
+			'footer-widgets',
+			'accessibility-ready',
+			'block-patterns',
+			'block-styles',
+			'buddypress',
+			'custom-background',
+			'custom-colors',
+			'custom-header',
+			'custom-logo',
+			'custom-menu',
+			'editor-style',
+			'featured-image-header',
+			'featured-images',
+			'front-page-post-form',
+			'full-width-template',
+			'microformats',
+			'post-formats',
+			'rtl-language-support',
+			'sticky-post',
+			'theme-options',
+			'threaded-comments',
+			'translation-ready',
+		);
+		return array_merge( $allowed_tags, self::get_subject_tags() );
 	}
 
-    /**
-     * Get the list of subject tags.
-     *
-     * @return array
-     */
-    public static function get_subject_tags() {
-        return array(
-            'blog',
-            'e-commerce',
-            'education',
-            'entertainment',
-            'food-and-drink',
-            'holiday',
-            'news',
-            'photography',
-            'portfolio'
-        );
-    }
+	/**
+	 * Get the list of subject tags.
+	 *
+	 * @return array
+	 */
+	public static function get_subject_tags() {
+		return array(
+			'blog',
+			'e-commerce',
+			'education',
+			'entertainment',
+			'food-and-drink',
+			'holiday',
+			'news',
+			'photography',
+			'portfolio'
+		);
+	}
 }
 $themechecks[] = new Style_Tags();

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -13,12 +13,12 @@ class Style_Tags implements themecheck {
 				$data = get_theme_data_from_contents( $content );
 
 				if ( ! $data['Tags'] ) {
-                    $this->error[] = '<span class="tc-lead tc-recommended">' . __('RECOMMENDED','theme-check') . '</span>: ' . __( '<strong>Tags:</strong> is either empty or missing in style.css header.', 'theme-check' )
+					$this->error[] = '<span class="tc-lead tc-recommended">' . __('RECOMMENDED','theme-check') . '</span>: ' . __( '<strong>Tags:</strong> is either empty or missing in style.css header.', 'theme-check' )
 					. ' ('. basename( dirname( $cssfile)) . ')';
 				} else {
-					$deprecated_tags    = array( 'flexible-width', 'fixed-width', 'black', 'blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'silver', 'tan', 'white', 'yellow', 'dark', 'light', 'fixed-layout', 'fluid-layout', 'responsive-layout', 'blavatar', 'holiday', 'photoblogging', 'seasonal' );
-					$allowed_tags       = self::get_allowed_tags();
-					$subject_tags       = self::get_subject_tags();
+					$deprecated_tags    = $this->get_deprecated_tags();
+					$allowed_tags       = $this->get_allowed_tags();
+					$subject_tags       = $this->get_subject_tags();
 					$subject_tags_count = 0;
 					$subject_tags_name  = '';
 
@@ -69,7 +69,7 @@ class Style_Tags implements themecheck {
 	 *
 	 * @return array
 	 */
-	public static function get_allowed_tags() {
+	private function get_allowed_tags() {
 		$allowed_tags = array(
 			'grid-layout',
 			'one-column',
@@ -112,7 +112,7 @@ class Style_Tags implements themecheck {
 	 *
 	 * @return array
 	 */
-	public static function get_subject_tags() {
+	private function get_subject_tags() {
 		return array(
 			'blog',
 			'e-commerce',
@@ -122,7 +122,36 @@ class Style_Tags implements themecheck {
 			'holiday',
 			'news',
 			'photography',
-			'portfolio'
+			'portfolio',
+		);
+	}
+
+	private function get_depricated_tags() {
+		return array(
+			'flexible-width',
+			'fixed-width',
+			'black',
+			'blue',
+			'brown',
+			'gray',
+			'green',
+			'orange',
+			'pink',
+			'purple',
+			'red',
+			'silver',
+			'tan',
+			'white',
+			'yellow',
+			'dark',
+			'light',
+			'fixed-layout',
+			'fluid-layout',
+			'responsive-layout',
+			'blavatar',
+			'holiday',
+			'photoblogging',
+			'seasonal',
 		);
 	}
 }

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -12,9 +12,9 @@ class Style_Tags implements themecheck {
 			if ( basename( $cssfile ) === 'style.css' ) {
 				$data = get_theme_data_from_contents( $content );
 
-					$this->error[] = '<span class="tc-lead tc-recommended">' . __('RECOMMENDED','theme-check') . '</span>: ' . __( '<strong>Tags:</strong> is either empty or missing in style.css header.', 'theme-check' )
-					. ' ('. basename( dirname( $cssfile)) . ')';
 				if ( ! $data['Tags'] ) {
+                    $this->error[] = '<span class="tc-lead tc-recommended">' . __('RECOMMENDED','theme-check') . '</span>: ' . __( '<strong>Tags:</strong> is either empty or missing in style.css header.', 'theme-check' )
+					. ' ('. basename( dirname( $cssfile)) . ')';
 				} else {
 					$deprecated_tags    = array( 'flexible-width', 'fixed-width', 'black', 'blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'silver', 'tan', 'white', 'yellow', 'dark', 'light', 'fixed-layout', 'fluid-layout', 'responsive-layout', 'blavatar', 'holiday', 'photoblogging', 'seasonal' );
 					$allowed_tags       = self::get_allowed_tags();

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -17,7 +17,7 @@ class Style_Tags implements themecheck {
 					. ' ('. basename( dirname( $cssfile)) . ')';
 				}
 				else {
-					$deprecated_tags = array("flexible-width","fixed-width","black","blue","brown","gray","green","orange","pink","purple","red","silver","tan","white","yellow","dark","light","fixed-layout","fluid-layout","responsive-layout","blavatar","holiday","photoblogging","seasonal");
+					$deprecated_tags    = array( 'flexible-width', 'fixed-width', 'black', 'blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'silver', 'tan', 'white', 'yellow', 'dark', 'light', 'fixed-layout', 'fluid-layout', 'responsive-layout', 'blavatar', 'holiday', 'photoblogging', 'seasonal' );
 					$allowed_tags       = self::get_allowed_tags();
 					$subject_tags       = self::get_subject_tags();
 					$subject_tags_count = 0;

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -83,6 +83,7 @@ class Style_Tags implements themecheck {
             'flexible-header',
             'footer-widgets',
             'accessibility-ready',
+            'block-patterns',
             'block-styles',
             'buddypress',
             'custom-background',

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -5,11 +5,11 @@ class Style_Tags implements themecheck {
 	function check( $php_files, $css_files, $other_files ) {
 
 		checkcount();
-		$ret = true;
+		$ret       = true;
 		$filenames = array();
 
-		foreach( $css_files as $cssfile => $content ) {
-			if ( basename( $cssfile ) === 'style.css' ) { 
+		foreach ( $css_files as $cssfile => $content ) {
+			if ( basename( $cssfile ) === 'style.css' ) {
 				$data = get_theme_data_from_contents( $content );
 
 				if ( !$data[ 'Tags' ] ) {
@@ -21,9 +21,9 @@ class Style_Tags implements themecheck {
 					$allowed_tags       = self::get_allowed_tags();
 					$subject_tags       = self::get_subject_tags();
 					$subject_tags_count = 0;
-					$subject_tags_name = "";
+					$subject_tags_name  = '';
 
-					foreach( $data[ 'Tags' ] as $tag ) {
+					foreach ( $data['Tags'] as $tag ) {
 
 						if ( strpos( strtolower( $tag ), "accessibility-ready") !== false ) {
 							$this->error[] = '<span class="tc-lead tc-info">'. __('INFO','theme-check'). '</span>: ' . __( 'Themes that use the tag accessibility-ready will need to undergo an accessibility review.','theme-check' ) . ' ' . __('See <a href="https://make.wordpress.org/themes/handbook/review/accessibility/">https://make.wordpress.org/themes/handbook/review/accessibility/</a>', 'theme-check' );
@@ -126,4 +126,4 @@ class Style_Tags implements themecheck {
         );
     }
 }
-$themechecks[] = new Style_Tags;
+$themechecks[] = new Style_Tags();

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -95,6 +95,7 @@ class Style_Tags implements themecheck {
 			'featured-images',
 			'front-page-post-form',
 			'full-width-template',
+			'full-site-editing',
 			'microformats',
 			'post-formats',
 			'rtl-language-support',

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -46,14 +46,14 @@ class Style_Tags implements themecheck {
 						if ( in_array( strtolower( $tag ), $allowed_tags ) ) {
 							if ( count( array_keys ($data[ 'Tags' ], $tag ) ) > 1) {
 								$this->error[] = '<span class="tc-lead tc-required">'. __('REQUIRED','theme-check'). '</span>: ' . sprintf( __('The tag %s is being used more than once, please remove it from your style.css header.', 'theme-check'), '<strong>' . $tag . '</strong>' );
-								$ret = false;
+								$ret           = false;
 							}
 						}
 					}
 
 					if ( $subject_tags_count > 3 ) {
 						$this->error[] = '<span class="tc-lead tc-required">'. __('REQUIRED','theme-check'). '</span>: ' . sprintf( __('A maximum of 3 subject tags are allowed. The theme has %1$u subjects tags ( %2$s ). Please remove the subject tags, which do not directly apply to the theme.', 'theme-check'), $subject_tags_count, '<strong>' . rtrim( $subject_tags_name, ', ' ) . '</strong>' ) . ' ' . '<a target="_blank" href="https://make.wordpress.org/themes/handbook/review/required/theme-tags/">' . __( 'See Theme Tags', 'theme-check' ) . '</a>';
-						$ret = false;
+						$ret           = false;
 					}
 				}
 			}

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -18,8 +18,8 @@ class Style_Tags implements themecheck {
 				}
 				else {
 					$deprecated_tags = array("flexible-width","fixed-width","black","blue","brown","gray","green","orange","pink","purple","red","silver","tan","white","yellow","dark","light","fixed-layout","fluid-layout","responsive-layout","blavatar","holiday","photoblogging","seasonal");
-					$allowed_tags = array('grid-layout',"one-column","two-columns","three-columns","four-columns","left-sidebar","right-sidebar","wide-blocks","flexible-header",'footer-widgets',"accessibility-ready","block-styles","buddypress","custom-background","custom-colors","custom-header","custom-menu","custom-logo","editor-style","featured-image-header","featured-images","front-page-post-form","full-width-template","microformats","post-formats","rtl-language-support","sticky-post","theme-options","threaded-comments","translation-ready",'blog','e-commerce','education','entertainment','food-and-drink','holiday','news','photography','portfolio');
-					$subject_tags = array('blog','e-commerce','education','entertainment','food-and-drink','holiday','news','photography','portfolio');
+					$allowed_tags       = self::get_allowed_tags();
+					$subject_tags       = self::get_subject_tags();
 					$subject_tags_count = 0;
 					$subject_tags_name = "";
 
@@ -64,5 +64,65 @@ class Style_Tags implements themecheck {
 	}
 
 	function getError() { return $this->error; }
+
+    /**
+     * Get full list of allowed tags - including subject tags.
+     *
+     * @return array
+     */
+	public static function get_allowed_tags() {
+		$allowed_tags = array(
+            'grid-layout',
+            'one-column',
+            'two-columns',
+            'three-columns',
+            'four-columns',
+            'left-sidebar',
+            'right-sidebar',
+            'wide-blocks',
+            'flexible-header',
+            'footer-widgets',
+            'accessibility-ready',
+            'block-styles',
+            'buddypress',
+            'custom-background',
+            'custom-colors',
+            'custom-header',
+            'custom-logo',
+            'custom-menu',
+            'editor-style',
+            'featured-image-header',
+            'featured-images',
+            'front-page-post-form',
+            'full-width-template',
+            'microformats',
+            'post-formats',
+            'rtl-language-support',
+            'sticky-post',
+            'theme-options',
+            'threaded-comments',
+            'translation-ready',
+        );
+        return array_merge( $allowed_tags, self::get_subject_tags() );
+	}
+
+    /**
+     * Get the list of subject tags.
+     *
+     * @return array
+     */
+    public static function get_subject_tags() {
+        return array(
+            'blog',
+            'e-commerce',
+            'education',
+            'entertainment',
+            'food-and-drink',
+            'holiday',
+            'news',
+            'photography',
+            'portfolio'
+        );
+    }
 }
 $themechecks[] = new Style_Tags;

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -12,9 +12,9 @@ class Style_Tags implements themecheck {
 			if ( basename( $cssfile ) === 'style.css' ) {
 				$data = get_theme_data_from_contents( $content );
 
-				if ( !$data[ 'Tags' ] ) {
 					$this->error[] = '<span class="tc-lead tc-recommended">' . __('RECOMMENDED','theme-check') . '</span>: ' . __( '<strong>Tags:</strong> is either empty or missing in style.css header.', 'theme-check' )
 					. ' ('. basename( dirname( $cssfile)) . ')';
+				if ( ! $data['Tags'] ) {
 				} else {
 					$deprecated_tags    = array( 'flexible-width', 'fixed-width', 'black', 'blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'silver', 'tan', 'white', 'yellow', 'dark', 'light', 'fixed-layout', 'fluid-layout', 'responsive-layout', 'blavatar', 'holiday', 'photoblogging', 'seasonal' );
 					$allowed_tags       = self::get_allowed_tags();

--- a/checks/style_tags.php
+++ b/checks/style_tags.php
@@ -15,8 +15,7 @@ class Style_Tags implements themecheck {
 				if ( !$data[ 'Tags' ] ) {
 					$this->error[] = '<span class="tc-lead tc-recommended">' . __('RECOMMENDED','theme-check') . '</span>: ' . __( '<strong>Tags:</strong> is either empty or missing in style.css header.', 'theme-check' )
 					. ' ('. basename( dirname( $cssfile)) . ')';
-				}
-				else {
+				} else {
 					$deprecated_tags    = array( 'flexible-width', 'fixed-width', 'black', 'blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'silver', 'tan', 'white', 'yellow', 'dark', 'light', 'fixed-layout', 'fluid-layout', 'responsive-layout', 'blavatar', 'holiday', 'photoblogging', 'seasonal' );
 					$allowed_tags       = self::get_allowed_tags();
 					$subject_tags       = self::get_subject_tags();


### PR DESCRIPTION
Adds the 'block-patterns' tag as an [allowed tag for themes to use](https://make.wordpress.org/themes/handbook/review/required/theme-tags/#features-tags) when adding their theme to .org directory

Fixes: #271 