### PR TITLE
Adapt checks for Full-Site Editing themes

### DIFF
--- a/checkbase.php
+++ b/checkbase.php
@@ -344,6 +344,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof TagCheck
 			|| $check instanceof Style_Needed
 			|| $check instanceof WidgetsCheck
+			|| $check instanceof GravatarCheck
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -340,8 +340,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 
 	// Remove theme checks that do not apply to FSE themes.
 	foreach ( $themechecks as $key => $check ) {
-		if ( $check instanceof File_Checks
-			|| $check instanceof TagCheck
+		if ( $check instanceof TagCheck
 			|| $check instanceof Style_Needed
 			|| $check instanceof WidgetsCheck
 			|| $check instanceof GravatarCheck

--- a/checkbase.php
+++ b/checkbase.php
@@ -352,6 +352,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof Basic_Checks
 			|| $check instanceof NavMenuCheck
 			|| $check instanceof PostThumbnailCheck
+			|| $check instanceof CustomCheck
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -349,6 +349,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof PostPaginationCheck
 			|| $check instanceof CommentPaginationCheck
 			|| $check instanceof Comment_Reply
+			|| $check instanceof Basic_Checks
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -26,19 +26,6 @@ foreach ( glob( dirname( __FILE__ ) . "/{$dir}/*.php" ) as $file ) {
 do_action( 'themecheck_checks_loaded' );
 
 function run_themechecks( $php, $css, $other ) {
-	/*
-	echo '<pre>';
-	foreach( $php as $key => $value ) {
-		var_dump( $key );
-	}
-
-	foreach( $other as $key => $value ) {
-		var_dump( $key );
-	}
-	echo '</pre>';
-	*/
-
-
 	global $themechecks;
 	$pass = true;
 

--- a/checkbase.php
+++ b/checkbase.php
@@ -345,6 +345,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof Style_Needed
 			|| $check instanceof WidgetsCheck
 			|| $check instanceof GravatarCheck
+			|| $check instanceof Title_Checks
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -351,6 +351,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof Comment_Reply
 			|| $check instanceof Basic_Checks
 			|| $check instanceof NavMenuCheck
+			|| $check instanceof PostThumbnailCheck
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -348,6 +348,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof Title_Checks
 			|| $check instanceof PostPaginationCheck
 			|| $check instanceof CommentPaginationCheck
+			|| $check instanceof Comment_Reply
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -346,6 +346,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof WidgetsCheck
 			|| $check instanceof GravatarCheck
 			|| $check instanceof Title_Checks
+			|| $check instanceof PostPaginationCheck
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -353,6 +353,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof NavMenuCheck
 			|| $check instanceof PostThumbnailCheck
 			|| $check instanceof CustomCheck
+			|| $check instanceof EditorStyleCheck
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -347,4 +347,6 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 
 	// Add FSE specific checks.
 	$themechecks[] = new FSE_Required_Files();
+
+	return true;
 }

--- a/checkbase.php
+++ b/checkbase.php
@@ -342,6 +342,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 	foreach ( $themechecks as $key => $check ) {
 		if ( $check instanceof File_Checks
 			|| $check instanceof TagCheck
+			|| $check instanceof Style_Needed
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -343,6 +343,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 		if ( $check instanceof File_Checks
 			|| $check instanceof TagCheck
 			|| $check instanceof Style_Needed
+			|| $check instanceof WidgetsCheck
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -347,6 +347,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof GravatarCheck
 			|| $check instanceof Title_Checks
 			|| $check instanceof PostPaginationCheck
+			|| $check instanceof CommentPaginationCheck
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checkbase.php
+++ b/checkbase.php
@@ -338,14 +338,15 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 		return false;
 	}
 
-	// Change the required files check to look for `index.html` instead of `index.php`.
+	// Remove theme checks that do not apply to FSE themes.
 	foreach ( $themechecks as $key => $check ) {
-		if ( ! $check instanceof File_Checks ) {
-			continue;
+		if ( $check instanceof File_Checks
+			|| $check instanceof TagCheck
+		) {
+			unset( $themechecks[ $key ] );
 		}
-
-		unset( $themechecks[ $key ] );
-
-		$themechecks[] = new FSE_Required_Files();
 	}
+
+	// Add FSE specific checks.
+	$themechecks[] = new FSE_Required_Files();
 }

--- a/checkbase.php
+++ b/checkbase.php
@@ -350,6 +350,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof CommentPaginationCheck
 			|| $check instanceof Comment_Reply
 			|| $check instanceof Basic_Checks
+			|| $check instanceof NavMenuCheck
 		) {
 			unset( $themechecks[ $key ] );
 		}

--- a/checks/fse-required-files.php
+++ b/checks/fse-required-files.php
@@ -16,13 +16,7 @@ class FSE_Required_Files implements themecheck {
 
 		$filenames = array();
 
-		foreach ( $php_files as $php_key => $phpfile ) {
-			array_push( $filenames, tc_filename( $php_key ) );
-		}
 		foreach ( $other_files as $php_key => $phpfile ) {
-			array_push( $filenames, tc_filename( $php_key ) );
-		}
-		foreach ( $css_files as $php_key => $phpfile ) {
 			array_push( $filenames, tc_filename( $php_key ) );
 		}
 

--- a/checks/fse-required-files.php
+++ b/checks/fse-required-files.php
@@ -29,8 +29,6 @@ class FSE_Required_Files implements themecheck {
 		$musthave = array(
 			'block-templates/index.html',
 			'experimental-theme.json',
-			'readme.txt',
-			'style.css',
 		);
 
 		foreach ( $musthave as $file ) {

--- a/checks/fse-required-files.php
+++ b/checks/fse-required-files.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Class FSE_Required_Files
+ *
+ * Checks that Full-Site Editing themes have the required files.
+ *
+ * This check is not added to the global array of checks, because it doesn't apply to all themes.
+ */
+class FSE_Required_Files implements themecheck {
+	protected $error = array();
+
+	function check( $php_files, $css_files, $other_files ) {
+
+		$ret = true;
+
+		$filenames = array();
+
+		foreach ( $php_files as $php_key => $phpfile ) {
+			array_push( $filenames, tc_filename( $php_key ) );
+		}
+		foreach ( $other_files as $php_key => $phpfile ) {
+			array_push( $filenames, tc_filename( $php_key ) );
+		}
+		foreach ( $css_files as $php_key => $phpfile ) {
+			array_push( $filenames, tc_filename( $php_key ) );
+		}
+
+		$musthave = array(
+			'block-templates/index.html',
+			'experimental-theme.json',
+			'readme.txt',
+			'style.css',
+		);
+
+		foreach ( $musthave as $file ) {
+			if ( ! in_array( $file, $filenames ) ) {
+				$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Could not find the file %s in the theme.', 'theme-check' ), '<strong>' . $file . '</strong>' );
+				$ret           = false;
+			}
+		}
+
+		return $ret;
+	}
+
+	function getError() { return $this->error; }
+}


### PR DESCRIPTION
This code is "good enough", by design. It's supposed to make it easier to upload experimental themes to WordPress.org without having to add code just for the sake of passing the checker.

As FSE themes become more stable, the Theme Checker as well as the checks would need a larger re-organization. So this can be revisited as part of that change down the line.

See #279.