### PR TITLE
Fix false positives in title checks

### DIFF
--- a/checks/title.php
+++ b/checks/title.php
@@ -28,7 +28,7 @@ class Title_Checks implements themecheck {
 
 			// Look for <title> and </title> tags.
 			checkcount();
-			if ( ( 0 <= strpos( $php, '<title>' ) || 0 <= strpos( $php, '</title>' ) ) && ! $titletag  ) {
+			if ( ( false !== strpos( $php, '<title>' ) || false !== strpos( $php, '</title>' ) ) && ! $titletag  ) {
 				$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . sprintf( __( 'The theme must not use the <strong>&lt;title&gt;</strong> tags. Found the tag in %1$s.', 'theme-check' ),
 					'<strong>' . $filename . '</strong>'
 				);
@@ -37,7 +37,7 @@ class Title_Checks implements themecheck {
 
 			// Check whether there is a call to wp_title().
 			checkcount();
-			if ( 0 <= strpos( $php, 'wp_title(' ) && ! $titletag ) {
+			if ( false !== strpos( $php, 'wp_title(' ) && ! $titletag ) {
 				$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . sprintf( __( 'The theme must not call to <strong>wp_title()</strong>. Found wp_title() in %1$s.', 'theme-check' ),
 					'<strong>' . $filename . '</strong>'
 				);


### PR DESCRIPTION
When `strpos` cannot find a string, it will return `false`. Therefore all these checks need to compare against `false`, else this leads to false positives.

To test, use a theme that has neither `title-tag` support, nor `<title>` or `wp_title()` anywhere. You'll see that the checker will nonetheless throw these errors:
```
REQUIRED: The theme must not use the <title> tags. Found the tag in index.php.
REQUIRED: The theme must not use the <title> tags. Found the tag in inc/class-require-gutenberg.php.
REQUIRED: The theme must not use the <title> tags. Found the tag in functions.php.
REQUIRED: The theme must not call to wp_title(). Found wp_title() in index.php.
REQUIRED: The theme must not call to wp_title(). Found wp_title() in inc/class-require-gutenberg.php.
REQUIRED: The theme must not call to wp_title(). Found wp_title() in functions.php.
```