### PR TITLE
CSS classes: Reduce level from required to recommended

### DIFF
--- a/checks/style_needed.php
+++ b/checks/style_needed.php
@@ -17,14 +17,6 @@ class Style_Needed implements themecheck {
 			'[ \t\/*#]*Text Domain:' => __( '<strong>Text Domain:</strong> is missing from your style.css header.', 'theme-check' ),
 			'[ \t\/*#]*Tested up to:' => __( '<strong>Tested up to:</strong> is missing from your style.css header. Also, this should be numbers only, so <em>5.0</em> and not <em>WP 5.0</em>', 'theme-check' ),
 			'[ \t\/*#]*Requires PHP:' => __( '<strong>Requires PHP:</strong> is missing from your style.css header.', 'theme-check' ),
-			'\.sticky' => __( '<strong>.sticky</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.bypostauthor' => __( '<strong>.bypostauthor</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.alignleft' => __( '<strong>.alignleft</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.alignright' => __( '<strong>.alignright</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.aligncenter' => __( '<strong>.aligncenter</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.wp-caption' => __( '<strong>.wp-caption</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.wp-caption-text' => __( '<strong>.wp-caption-text</strong> css class is needed in your theme css.', 'theme-check' ),
-			'\.gallery-caption' => __( '<strong>.gallery-caption</strong> css class is needed in your theme css.', 'theme-check' ),
 			'\.screen-reader-text' => __( '<strong>.screen-reader-text</strong> css class is needed in your theme css. See See: <a href="http://codex.wordpress.org/CSS#WordPress_Generated_Classes">the Codex</a> for an example implementation.', 'theme-check' )
 		);
 

--- a/checks/style_suggested.php
+++ b/checks/style_suggested.php
@@ -21,6 +21,23 @@ class Style_Suggested implements themecheck {
 			}
 		}
 
+		$css_class_checks = array(
+			'\.sticky' => __( '<strong>.sticky</strong> css class is recommended in your theme css.', 'theme-check' ),
+			'\.bypostauthor' => __( '<strong>.bypostauthor</strong> css class is recommended in your theme css.', 'theme-check' ),
+			'\.alignleft' => __( '<strong>.alignleft</strong> css class is recommended in your theme css.', 'theme-check' ),
+			'\.alignright' => __( '<strong>.alignright</strong> css class is recommended in your theme css.', 'theme-check' ),
+			'\.aligncenter' => __( '<strong>.aligncenter</strong> css class is recommended in your theme css.', 'theme-check' ),
+			'\.wp-caption' => __( '<strong>.wp-caption</strong> css class is recommended in your theme css.', 'theme-check' ),
+			'\.wp-caption-text' => __( '<strong>.wp-caption-text</strong> css class is recommended in your theme css.', 'theme-check' ),
+			'\.gallery-caption' => __( '<strong>.gallery-caption</strong> css class is recommended in your theme css.', 'theme-check' ),
+		);
+
+		foreach ($css_class_checks as $key => $check) {
+			if ( !preg_match( '/' . $key . '/i', $css, $matches ) ) {
+				$this->error[] = sprintf('<span class="tc-lead tc-recommended">' . __('RECOMMENDED', 'theme-check' ) . '</span>: <strong>' . $check . '</strong>' );
+			}
+		}
+
 		return $ret;
 	}
 


### PR DESCRIPTION
Moves 

```
.sticky
.bypostauthor
.alignleft
.alignright
.aligncenter
.wp-caption
.wp-caption-text
.gallery-caption
```

to style_suggested.php and make them recommended instead of required.