### PR TITLE
Allow file_get_contents() and discourage usage of WP_Filesystem for basic IO tasks

### DIFF
--- a/checks/filesystem-http.php
+++ b/checks/filesystem-http.php
@@ -36,7 +36,6 @@ class FilesystemHttpCheck implements themecheck {
 							$check,
 							$grep
 						);
-						$ret = false;
 					}
 				}
 			}

--- a/checks/filesystem-http.php
+++ b/checks/filesystem-http.php
@@ -1,5 +1,5 @@
 <?php
-class MalwareCheck implements themecheck {
+class FilesystemHttpCheck implements themecheck {
 	protected $error = array();
 
 	function check( $php_files, $css_files, $other_files ) {
@@ -46,4 +46,4 @@ class MalwareCheck implements themecheck {
 
 	function getError() { return $this->error; }
 }
-$themechecks[] = new MalwareCheck;
+$themechecks[] = new FilesystemHttpCheck;

--- a/checks/malware.php
+++ b/checks/malware.php
@@ -6,8 +6,16 @@ class MalwareCheck implements themecheck {
 		$ret = true;
 
 		$checks = array(
-			'/[^a-z0-9](?<!_)(file_get_contents|curl_exec|curl_init|readfile|fopen|fsockopen|pfsockopen|fclose|fread|fwrite|file_put_contents)\s?\(/' => __( 'File operations should use the WP_Filesystem methods instead of direct PHP filesystem calls', 'theme-check' ),
-			);
+			// Filesystem operations are not advised. file_get_contents() is allowed.
+			'/[^a-z0-9](?<!_)(readfile|fopen)\s?\(/i' => __( 'File read operations should use file_get_contents() but are discouraged unless required', 'theme-check' ),
+			'/[^a-z0-9](?<!_)(fopen|fclose|fread|fwrite|file_put_contents)\s?\(/i' => __( 'File write operations should are avoided unless necessary', 'theme-check' ),
+
+			// WP_Filesystem should only be used for theme upgrade operations. It should not be used to avoid the fopen()/file_put_contents()/etc warnings.
+			'/[^a-z0-9](?<!_)(WP_Filesystem)\s?\(/i' => __( 'WP_Filesystem should only be used for theme upgrade operations, not for all file operations. Consider using file_get_contents(), scandir(), or glob()', 'theme-check' ),
+
+			// HTTP Requests should use WP_HTTP.
+			'/[^a-z0-9](?<!_)(curl_exec|curl_init|fsockopen|pfsockopen|stream_context_create)\s?\(/' => __( 'HTTP requests should be made using the WordPress HTTP wrappers, such as wp_safe_remote_get() and wp_safe_remote_post()', 'theme-check' ),
+		);
 
 		foreach ( $php_files as $php_key => $phpfile ) {
 			foreach ( $checks as $key => $check ) {
@@ -16,13 +24,20 @@ class MalwareCheck implements themecheck {
 				if ( preg_match_all( $key, $phpfile, $matches ) ) {
 					$filename = tc_filename( $php_key );
 
-						foreach ($matches[1] as $match ) {
-							$error = ltrim( $match, '(' );
-							$error = rtrim( $error, '(' );
-							$grep = tc_grep( $error, $php_key );
-							$this->error[] = sprintf('<span class="tc-lead tc-warning">'.__('WARNING','theme-check').'</span>: '.__('%1$s was found in the file %2$s %3$s.%4$s', 'theme-check'), '<strong>' . $error. '</strong>', '<strong>' . $filename . '</strong>', $check, $grep );
-							$ret = false;
-						}
+					foreach ( $matches[1] as $match ) {
+						$error = ltrim( $match, '(' );
+						$error = rtrim( $error, '(' );
+
+						$grep = tc_grep( $error, $php_key );
+						$this->error[] = sprintf(
+							'<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . __( '%1$s was found in the file %2$s %3$s. %4$s', 'theme-check' ),
+							'<strong>' . $error. '</strong>',
+							'<strong>' . $filename . '</strong>',
+							$check,
+							$grep
+						);
+						$ret = false;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR removes warnings about `file_get_contents()` and encourages it's usage over WP_Filesystem for general IO operations.

HTTP methods are also replaced with a new error message, to use the WordPress HTTP library instead.