### PR TITLE
Fix invalid regular expression

### DIFF
--- a/checks/customizer.php
+++ b/checks/customizer.php
@@ -25,7 +25,7 @@ class CustomizerCheck implements themecheck {
 						/* Clean up our match to be able to present the results better. */
 						$match         = preg_split( '/,/', $match );
 						$filename      = tc_filename( $file_path );
-						$grep          = tc_preg( $match[0], $file_path );
+						$grep          = tc_preg( '/' . preg_quote( $match[0], '/' ) . '/', $file_path );
 						$grep          = preg_split( '/,/', $grep );
 						$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Found a Customizer setting called %1$s in %2$s that did not have a sanitization callback function. ', 'theme-check' ) . __( 'Every call to the <strong>add_setting()</strong> method needs to have a sanitization callback function passed.', 'theme-check' ),
 							'<strong>' . $match[0] . '</strong>',

--- a/checks/customizer.php
+++ b/checks/customizer.php
@@ -27,10 +27,15 @@ class CustomizerCheck implements themecheck {
 						$filename      = tc_filename( $file_path );
 						$grep          = tc_preg( '/' . preg_quote( $match[0], '/' ) . '/', $file_path );
 						$grep          = preg_split( '/,/', $grep );
-						$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Found a Customizer setting called %1$s in %2$s that did not have a sanitization callback function. ', 'theme-check' ) . __( 'Every call to the <strong>add_setting()</strong> method needs to have a sanitization callback function passed.', 'theme-check' ),
-							'<strong>' . $match[0] . '</strong>',
-							'<strong>' . $filename . '</strong>'
-						) . $grep[0];
+						$this->error[] = sprintf(
+							'<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: %s %s',
+							sprintf(
+								__( 'Found a Customizer setting called %1$s in %2$s that did not have a sanitization callback function. ', 'theme-check' ) . __( 'Every call to the <strong>add_setting()</strong> method needs to have a sanitization callback function passed.', 'theme-check' ),
+								'<strong>' . $match[0] . '</strong>',
+								'<strong>' . $filename . '</strong>'
+							),
+							$grep[0]
+						);
 						$ret = false;
 					} else {
 						// There's a callback, check that no empty parameter is passed.
@@ -39,10 +44,15 @@ class CustomizerCheck implements themecheck {
 							$filename      = tc_filename( $file_path );
 							$grep          = tc_preg( '/[\'"](?:sanitize_callback|sanitize_js_callback)[\'"]\s*=>\s*[\'"]\s*[\'"]/', $file_path );
 							$grep          = preg_split( '/,/', $grep );
-							$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Found a Customizer setting called %1$s in %2$s that had an empty value passed as sanitization callback. You need to pass a function name as sanitization callback.', 'theme-check' ),
-								'<strong>' . $match[0] . '</strong>',
-								'<strong>' . $filename . '</strong>'
-							) . $grep[0];
+							$this->error[] = sprintf(
+								'<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: %s %s',
+								sprintf(
+									__( 'Found a Customizer setting called %1$s in %2$s that had an empty value passed as sanitization callback. You need to pass a function name as sanitization callback.', 'theme-check' ) .
+									'<strong>' . $match[0] . '</strong>',
+									'<strong>' . $filename . '</strong>'
+								),
+								$grep[0]
+							);
 							$ret = false;
 						}
 					}


### PR DESCRIPTION
The Customizer checks can cause invalid regular expressions to be generated under certain situations. This PR fixes that while making the error code cleaner.