### PR TITLE
Add a deploy action, to push it to the WordPress.org plugin directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,10 @@
 /.github export-ignore
 /.phpcs.xml.dist export-ignore
 /.stylelintrc export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/composer.json export-ignore
+/composer.lock export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to WordPress.org
+on:
+  release:
+    types: [published]
+jobs:
+  tag:
+    name: New release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: WordPress Plugin Deploy
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      with:
+        generate-zip: true
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+    - name: Upload release asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{github.workspace}}/${{ github.event.repository.name }}.zip
+        asset_name: ${{ github.event.repository.name }}.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
The attached GitHub workflow deploys the plugin to the plugin directory using [10up's plugin deploy action](https://github.com/10up/action-wordpress-plugin-deploy).

It's triggered by a Release being created on GitHub.

To release a new version with this:
 - update plugin header version string
 - update readme.txt stable tag
 - tag/release a release
 - wait a few minutes and see it's updated on WordPress.org.
