### PR TITLE
Avoid false positives when .svn/.git/.hg/.bzr exists within the path to a theme.

### DIFF
--- a/checks/directories.php
+++ b/checks/directories.php
@@ -5,27 +5,30 @@ class DirectoriesCheck implements themecheck {
 
 	function check( $php_files, $css_files, $other_files ) {
 
+		$excluded_directories = array(
+			'.git',
+			'.svn',
+			'.hg',
+			'.bzr',
+		);
+
 		$ret = true;
-		$found = false;
 
-		foreach ( $php_files as $name => $file ) {
+		$all_filenames = array_merge(
+			array_keys( $php_files ),
+			array_keys( $css_files ),
+			array_keys( $other_files ),
+		);
+
+		foreach ( $all_filenames as $path ) {
 			checkcount();
-			if ( strpos( $name, '.git' ) !== false || strpos( $name, '.svn' ) !== false ) $found = true;
-		}
 
-		foreach ( $css_files as $name => $file ) {
-			checkcount();
-			if ( strpos( $name, '.git' ) !== false || strpos( $name, '.svn' ) !== false || strpos( $name, '.hg' ) !== false || strpos( $name, '.bzr' ) !== false ) $found = true;
-		}
+			$filename = basename( $path );
 
-		foreach ( $other_files as $name => $file ) {
-			checkcount();
-			if ( strpos( $name, '.git' ) !== false || strpos( $name, '.svn' ) !== false || strpos( $name, '.hg' ) !== false || strpos( $name, '.bzr' ) !== false ) $found = true;
-		}
-
-		if ($found) {
-			$this->error[] = sprintf('<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Please remove any extraneous directories like .git or .svn from the ZIP file before uploading it.', 'theme-check') );
-			$ret = false;
+			if ( in_array( $filename, $excluded_directories, true ) ) {
+				$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Please remove any extraneous directories like .git or .svn from the ZIP file before uploading it.', 'theme-check' );
+				$ret = false;
+			}
 		}
 
 		return $ret;
@@ -33,4 +36,5 @@ class DirectoriesCheck implements themecheck {
 
 	function getError() { return $this->error; }
 }
+
 $themechecks[] = new DirectoriesCheck;


### PR DESCRIPTION
Combines the logic and avoid false positives where .svn/.git/.hg/.bzr exist within a filename/file path but are not actually present in the theme.

An example of this would be having Theme Check installed in a WordPress install at `~/public_html/company.hg/`.

This also extends the `.hg` and `.bzr` checks to PHP files.

Fixes #193