### PR TITLE
Allow `tc_filename()` to return theme-relative filenames

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+= nextrelease =
+* Fix: `tc_filename()` to always return theme-relative paths when possible.
+* Fix: Correct the block theme adaptation check to work in WordPress.org Theme Uploader
+
 = 20210617 =
 * Introduced a generic function, run_themechecks_against_theme(), that allows it to be run against a WP_Theme instance, rather than relying upon global state
 * Adapted checks for block themes. Create a list of the checks that are skipped for block themes (full site editing themes)

--- a/checkbase.php
+++ b/checkbase.php
@@ -16,6 +16,10 @@ $themechecks = array();
 global $checkcount;
 $checkcount = 0;
 
+// current WP_Theme being tested. Internal use only.
+global $theme_check_current_theme;
+$theme_check_current_theme = false;
+
 // interface that all checks should implement.
 interface themecheck {
 
@@ -217,7 +221,7 @@ function tc_filename( $file ) {
 	$filename = false;
 
 	// If we know the WP_Theme object, we can get the exact path.
-	if ( ! empty( $theme_check_current_theme ) ) {
+	if ( $theme_check_current_theme ) {
 
 		$root = trailingslashit( $theme_check_current_theme->get_theme_root() );
 		if ( $root === substr( $file, 0, strlen( $root ) ) ) {

--- a/checkbase.php
+++ b/checkbase.php
@@ -220,21 +220,13 @@ function tc_filename( $file ) {
 
 	// If we know the WP_Theme object, we can get the exact path.
 	if ( $theme_check_current_theme ) {
+		$theme_files = $theme_check_current_theme->get_files(
+			null /* all file types */,
+			-1 /* infinite recursion */,
+			true /* include parent theme files */
+		);
 
-		$root = trailingslashit( $theme_check_current_theme->get_theme_root() );
-		if ( $root === substr( $file, 0, strlen( $root ) ) ) {
-			// Trim the root path off first.
-			$filename = substr( $file, strlen( $root ) );
-
-			// Trim off the Stylesheet or Template from the file path.
-			$stylesheet = $theme_check_current_theme->get_stylesheet();
-			$template   = $theme_check_current_theme->get_template();
-			if ( 0 === strpos( $filename, $stylesheet ) ) {
-				$filename = substr( $filename, strlen( $stylesheet ) + 1 );
-			} elseif ( 0 === strpos( $filename, $template ) ) {
-				$filename = substr( $filename, strlen( $template ) + 1 );
-			}
-		}
+		$filename = array_search( $file, $theme_files, true );
 	}
 
 	// If the $file exists within a theme-like folder, use that/

--- a/checkbase.php
+++ b/checkbase.php
@@ -98,9 +98,7 @@ function run_themechecks( $php, $css, $other, $context = array() ) {
 	global $themechecks, $theme_check_current_theme;
 
 	// Provide context to some functions that need to know the current theme, but aren't passed the object.
-	if ( isset( $context['theme'] ) ) {
-		$theme_check_current_theme = $context['theme'];
-	}
+	$theme_check_current_theme = isset( $context['theme'] ) ? $context['theme'] : false;
 
 	$pass = true;
 
@@ -116,7 +114,7 @@ function run_themechecks( $php, $css, $other, $context = array() ) {
 		}
 	}
 
-	unset( $theme_check_current_theme );
+	$theme_check_current_theme = false;
 
 	return $pass;
 }

--- a/checkbase.php
+++ b/checkbase.php
@@ -229,8 +229,8 @@ function tc_filename( $file ) {
 		$filename = array_search( $file, $theme_files, true );
 	}
 
-	// If the $file exists within a theme-like folder, use that/
-	// does not support themes nested in directories such as wp-content/themes/public/my-theme/index.php
+	// If the $file exists within a theme-like folder, use that.
+	// Does not support themes nested in directories such as wp-content/themes/pub/wporg-themes/index.php
 	if ( ! $filename && preg_match( '!/themes/[^/]+/(.*)$!i', $file, $out ) ) {
 		$filename = $out[1];
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -53,5 +53,4 @@ If **either** of these two vars are defined a new trac tickbox will appear next 
 
 == Changelog ==
 
-= 20200504.1 =
-* Changes can be found in the changelog.txt file.
+Changes can be found in [the changelog.txt file](https://github.com/WordPress/theme-check/blob/master/changelog.txt).


### PR DESCRIPTION
Allow `tc_filename()` to return theme-relative filenames when themes are loaded from custom directories, or are nested within other folders in wp-content/themes.

Fixes #369