### PR TITLE
Update the version display in main.php

### DIFF
--- a/main.php
+++ b/main.php
@@ -91,13 +91,22 @@ function check_main( $theme_slug ) {
 
 	$plugins = get_plugins( '/theme-check' );
 	$version = explode( '.', $plugins['theme-check.php']['Version'] );
-	echo '<p>' . sprintf(
-		esc_html__( 'Running %1$s tests against %2$s using Guidelines Version: %3$s Plugin revision: %4$s', 'theme-check' ),
-		'<strong>' . esc_html( $checkcount ) . '</strong>',
-		'<strong>' . esc_html( $theme['Title'] ) . '</strong>',
-		'<strong>' . esc_html( $version[0] ) . '</strong>',
-		'<strong>' . esc_html( $version[0] ) . '</strong>'
-	) . '</p>';
+
+	if ( isset( $version[0] ) && isset( $version[1] ) ) {
+		echo '<p>' . sprintf(
+			esc_html__( 'Running %1$s tests against %2$s using Guidelines Version: %3$s Plugin revision: %4$s', 'theme-check' ),
+			'<strong>' . esc_html( $checkcount ) . '</strong>',
+			'<strong>' . esc_html( $theme['Title'] ) . '</strong>',
+			'<strong>' . esc_html( $version[0] ) . '</strong>',
+			'<strong>' . esc_html( $version[1] ) . '</strong>'
+		) . '</p>';
+	} else {
+		echo '<p>' . sprintf(
+			esc_html__( 'Running %1$s tests against %2$s.', 'theme-check' ),
+			'<strong>' . esc_html( $checkcount ) . '</strong>',
+			'<strong>' . esc_html( $theme['Title'] ) . '</strong>',
+		) . '</p>';
+	}
 
 	$results = display_themechecks();
 

--- a/main.php
+++ b/main.php
@@ -104,7 +104,7 @@ function check_main( $theme_slug ) {
 		echo '<p>' . sprintf(
 			esc_html__( 'Running %1$s tests against %2$s.', 'theme-check' ),
 			'<strong>' . esc_html( $checkcount ) . '</strong>',
-			'<strong>' . esc_html( $theme['Title'] ) . '</strong>',
+			'<strong>' . esc_html( $theme['Title'] ) . '</strong>'
 		) . '</p>';
 	}
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/theme-check/issues/358

This solves a PHP notice when the plugin version number is missing the _revision._
It checks if both the version and revision keys are set and displays the versions. 
If not, only the number of checks that are run are displayed.

Yes, this is overkill :), the error shouldn't occur as long as the plugin version format is the expected format.
`Requirement date .  revision number`