### PR TITLE
Try: Add simplified readme validator

### DIFF
--- a/checks/class-file-check.php
+++ b/checks/class-file-check.php
@@ -66,7 +66,7 @@ class File_Check implements themecheck {
 			'favicon\.ico'        => __( 'Favicon', 'theme-check' ),
 		);
 
-		$musthave = array( 'index.php', 'style.css', 'readme.txt' );
+		$musthave = array( 'index.php', 'style.css' );
 
 		checkcount();
 

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Validate readme files.
+ *
+ * @package Theme Check
+ */
+
+class Readme_Check implements themecheck {
+	/**
+	 * Error messages, warnings and info notices.
+	 *
+	 * @var array $error
+	 */
+	protected $error = array();
+
+	/**
+	 * Latest WordPress version
+	 *
+	 * @var string $latest_wordpress_version
+	 */
+	protected $latest_wordpress_version = '5.9';
+
+	/**
+	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
+	 *
+	 * @param array $php_files File paths and content for PHP files.
+	 * @param array $css_files File paths and content for CSS files.
+	 * @param array $other_files Folder names, file paths and content for other files.
+	 */
+	public function check( $php_files, $css_files, $other_files ) {
+
+		checkcount();
+
+		// Get a list of file names and check for the readme.
+		$other_filenames = array();
+		foreach ( $other_files as $path => $contents ) {
+			$other_filenames[] = tc_filename( $path );
+			if ( tc_filename( $path ) == 'readme.txt' || tc_filename( $path ) == 'readme.md' ) {
+				$readme = $contents;
+				break;
+			}
+		}
+
+		// Publish an error if there is no readme file.
+		if ( ! in_array( 'readme.txt', $other_filenames, true ) && ! in_array( 'readme.md', $other_filenames, true )) {
+			$this->error[] = sprintf(
+				'<span class="tc-lead tc-required">%s</span>: %s',
+				__( 'ERROR', 'theme-check' ),
+				__( 'The readme file is missing.', 'theme-check' ),
+			);
+			$ret = false;
+		} else {
+			// Parse the content of the readme.
+			$readme = new Readme_Parser( $readme );
+
+			// Fatal errors:
+			if ( empty( $readme->name ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-required">%s</span>: %s',
+					__( 'README ERROR', 'theme-check' ),
+					/* translators: 1: 'Theme Name' section title, 2: 'Theme Name' */
+					sprintf(
+						__( 'Could not find a theme name in the readme. Theme name format looks like: %1$s. Please change %2$s to reflect the actual name of your theme.', 'theme-check' ),
+						'<code>=== Theme Name ===</code>',
+						'<code>Theme Name</code>'
+					)
+				);
+				$ret = false;
+			}
+	
+			// Warnings.
+			if ( isset( $readme->warnings['requires_header_ignored'] ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+					__( 'README WARNING', 'theme-check' ),
+						/* translators: 1: theme header tag; 2: Example version 5.0. 3: Example version 4.9. */
+					sprintf(
+						__( 'The %1$s field in the readme was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'theme-check' ),
+						'<code>Requires at least</code>',
+						'<code>' . number_format( $latest_wordpress_version, 1 ) . '</code>',
+						'<code>' . number_format( $latest_wordpress_version - 0.1, 1 ) . '</code>'
+					)
+				);
+			} elseif ( empty( $readme->requires ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+					__( 'README WARNING', 'theme-check' ),
+					sprintf(
+						/* translators: %s: plugin header tag */
+						__( 'The %s field is missing from the readme.', 'theme-check' ),
+						'<code>Requires at least</code>'
+					)
+				);
+			}
+
+			if ( isset( $readme->warnings['tested_header_ignored'] ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+					__( 'README WARNING', 'theme-check' ),
+					sprintf(
+						/* translators: 1: theme header tag; 2: Example version 5.0. 3: Example version 5.1. */
+						__( 'The %1$s field in the readme was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'theme-check' ),
+						'<code>Tested up to</code>',
+						'<code>' . number_format( $latest_wordpress_version, 1 ) . '</code>',
+						'<code>' . number_format( $latest_wordpress_version + 0.1, 1 ) . '</code>'
+					)
+				);
+			} elseif ( empty( $readme->tested ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+						__( 'README WARNING', 'theme-check' ),
+						sprintf(
+							/* translators: %s: plugin header tag */
+							__( 'The %s field is missing from the readme file.', 'wporg-plugins' ),
+							'<code>Tested up to</code>'
+						)
+				);
+			}
+
+			if ( isset( $readme->warnings['requires_php_header_ignored'] ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+					__( 'README WARNING', 'theme-check' ),
+					sprintf(
+						/* translators: 1: plugin header tag; 2: Example version 5.2.4. 3: Example version 7.0. */
+						__( 'The %1$s field in the readme was ignored. This field should only contain a PHP version such as %2$s or %3$s.', 'theme-check' ),
+						'<code>Requires PHP</code>',
+						'<code>5.2.4</code>',
+						'<code>7.0</code>'
+					)
+				);
+			} else if ( empty( $readme->requires_php ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+					__( 'README WARNING', 'theme-check' ),
+					sprintf(
+						/* translators: %s: plugin header tag */
+						__( 'The %s field is missing from the readme.', 'theme-check' ),
+						'<code>Requires PHP</code>'
+					)
+				);
+			}
+
+			if ( isset( $readme->warnings['contributor_ignored'] ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+					__( 'README WARNING', 'theme-check' ),
+					sprintf(
+						/* translators: %s: theme header tag */
+						__( 'One or more contributors listed in the readme were ignored. The %s field should only contain WordPress.org usernames. Remember that usernames are case-sensitive.', 'theme-check' ),
+						'<code>Contributors</code>'
+					)
+				);
+			} elseif ( ! count( $readme->contributors ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+					__( 'README WARNING', 'theme-check' ),
+					sprintf(
+						/* translators: %s: theme header tag */
+						__( 'The %s field is missing from the readme.', 'theme-check' ),
+						'<code>Contributors</code>'
+					)
+				);
+			}
+
+			if ( empty( $readme->license ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+					__( 'README WARNING', 'theme-check' ),
+					sprintf(
+						/* translators: %s: theme header tag */
+						__( 'The %s field is missing from the readme.', 'theme-check' ),
+						'<code>License</code>'
+					)
+				);
+			}
+
+			if ( empty( $readme->license_uri ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-warning">%s</span>: %s',
+					__( 'README WARNING', 'theme-check' ),
+					sprintf(
+						/* translators: %s: theme header tag */
+						__( 'The %s field is missing from the readme.', 'theme-check' ),
+						'<code>License URI</code>'
+					)
+				);
+			}
+
+			// Info.
+			if ( empty( $readme->sections['description'] ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-info ">%s</span>: %s',
+					__( 'README INFO', 'theme-check' ),
+					sprintf(
+						/* translators: %s: section title */
+						__( 'No %s section was found in the readme.', 'theme-check' ),
+						'<code>== Description ==</code>'
+					)
+				);
+			}
+
+			if ( empty( $readme->sections['faq'] ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-info ">%s</span>: %s',
+					__( 'README INFO', 'theme-check' ),
+					sprintf(
+						/* translators: %s: section title */
+						__( 'No %s section was found in the readme.', 'theme-check' ),
+						'<code>== Frequently Asked Questions ==</code>'
+					)
+				);
+			}
+
+			if ( empty( $readme->sections['changelog'] ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-info ">%s</span>: %s',
+					__( 'README INFO', 'theme-check' ),
+					sprintf(
+						/* translators: %s: section title */
+						__( 'No %s section was found in the readme.', 'theme-check' ),
+						'<code>== Changelog ==</code>'
+					)
+				);
+			}
+
+		}
+	}
+
+	/**
+	 * Get error messages from the checks.
+	 *
+	 * @return array Error message.
+	 */
+	public function getError() {
+		return $this->error;
+	}
+}
+
+$themechecks[] = new Readme_Check();

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -23,9 +23,19 @@ class Readme_Check implements themecheck {
 	 */
 	protected $theme;
 
+	/**
+	 * Theme slug.
+	 *
+	 * @var object $slug
+	 */
+	protected $slug;
+
 	function set_context( $data ) {
 		if ( isset( $data['theme'] ) ) {
 			$this->theme = $data['theme'];
+		}
+		if ( isset( $data['slug'] ) ) {
+			$this->slug = $data['slug'];
 		}
 	}
 
@@ -54,17 +64,17 @@ class Readme_Check implements themecheck {
 		checkcount();
 
 		// Get a list of file names and check for the readme.
-		$other_filenames = array();
+		$readme        = '';
+
+		// Get the contents of themeslug/filename:
 		foreach ( $other_files as $path => $contents ) {
-			$other_filenames[] = tc_filename( $path );
-			if ( tc_filename( $path ) == 'readme.txt' || tc_filename( $path ) == 'readme.md' ) {
-				$readme = $contents;
-				break;
+			if ( stripos( $path, $this->slug . '/readme.txt' ) || stripos( $path, $this->slug . '/readme.md' ) !== false ) {
+				$readme .= $contents;
 			}
 		}
 
 		// Publish an error if there is no readme file.
-		if ( ! in_array( 'readme.txt', $other_filenames, true ) && ! in_array( 'readme.md', $other_filenames, true ) ) {
+		if ( empty( $readme) ) {
 			$this->error[] = sprintf(
 				'<span class="tc-lead tc-required">%s</span>: %s',
 				__( 'REQUIRED', 'theme-check' ),

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -64,7 +64,7 @@ class Readme_Check implements themecheck {
 		checkcount();
 
 		// Get a list of file names and check for the readme.
-		$readme        = '';
+		$readme = '';
 
 		// Get the contents of themeslug/filename:
 		foreach ( $other_files as $path => $contents ) {
@@ -74,7 +74,7 @@ class Readme_Check implements themecheck {
 		}
 
 		// Publish an error if there is no readme file.
-		if ( empty( $readme) ) {
+		if ( empty( $readme ) ) {
 			$this->error[] = sprintf(
 				'<span class="tc-lead tc-required">%s</span>: %s',
 				__( 'REQUIRED', 'theme-check' ),

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -16,13 +16,6 @@ class Readme_Check implements themecheck {
 	protected $error = array();
 
 	/**
-	 * Latest WordPress version
-	 *
-	 * @var string $latest_wordpress_version
-	 */
-	protected $latest_wordpress_version = '5.8';
-
-	/**
 	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
 	 *
 	 * @param array $php_files File paths and content for PHP files.
@@ -30,6 +23,13 @@ class Readme_Check implements themecheck {
 	 * @param array $other_files Folder names, file paths and content for other files.
 	 */
 	public function check( $php_files, $css_files, $other_files ) {
+
+		/**
+		 * Latest WordPress version
+		 *
+		 * @var string $latest_wordpress_version
+		 */
+		$latest_wordpress_version = '5.8';
 
 		checkcount();
 
@@ -143,13 +143,13 @@ class Readme_Check implements themecheck {
 				);
 			}
 
-			if ( isset( $readme->warnings['contributor_ignored'] ) ) {
+			if ( 2 <= count( $readme->contributors ) ) {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-warning">%s</span>: %s',
 					__( 'README WARNING', 'theme-check' ),
 					sprintf(
 						/* translators: %s: theme header tag */
-						__( 'One or more contributors listed in the readme were ignored. The %s field should only contain WordPress.org usernames. Remember that usernames are case-sensitive.', 'theme-check' ),
+						__( 'The %s field should only contain one WordPress.org username. Remember that usernames are case-sensitive.', 'theme-check' ),
 						'<code>Contributors</code>'
 					)
 				);
@@ -159,7 +159,7 @@ class Readme_Check implements themecheck {
 					__( 'README WARNING', 'theme-check' ),
 					sprintf(
 						/* translators: %s: theme header tag */
-						__( 'The %s field is missing from the readme.', 'theme-check' ),
+						__( 'The %s field is missing from the readme or is empty.', 'theme-check' ),
 						'<code>Contributors</code>'
 					)
 				);

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -45,7 +45,7 @@ class Readme_Check implements themecheck {
 		if ( ! in_array( 'readme.txt', $other_filenames, true ) && ! in_array( 'readme.md', $other_filenames, true ) ) {
 			$this->error[] = sprintf(
 				'<span class="tc-lead tc-required">%s</span>: %s',
-				__( 'ERROR', 'theme-check' ),
+				__( 'REQUIRED', 'theme-check' ),
 				__( 'The readme file is missing.', 'theme-check' )
 			);
 			$ret           = false;

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -18,7 +18,7 @@ class Readme_Check implements themecheck {
 	 *
 	 * @var string $latest_wordpress_version
 	 */
-	protected $latest_wordpress_version = '5.9';
+	protected $latest_wordpress_version = '5.8';
 
 	/**
 	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
@@ -42,18 +42,18 @@ class Readme_Check implements themecheck {
 		}
 
 		// Publish an error if there is no readme file.
-		if ( ! in_array( 'readme.txt', $other_filenames, true ) && ! in_array( 'readme.md', $other_filenames, true )) {
+		if ( ! in_array( 'readme.txt', $other_filenames, true ) && ! in_array( 'readme.md', $other_filenames, true ) ) {
 			$this->error[] = sprintf(
 				'<span class="tc-lead tc-required">%s</span>: %s',
 				__( 'ERROR', 'theme-check' ),
-				__( 'The readme file is missing.', 'theme-check' ),
+				__( 'The readme file is missing.', 'theme-check' )
 			);
-			$ret = false;
+			$ret           = false;
 		} else {
 			// Parse the content of the readme.
 			$readme = new Readme_Parser( $readme );
 
-			// Fatal errors:
+			// Error.
 			if ( empty( $readme->name ) ) {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-required">%s</span>: %s',
@@ -67,13 +67,13 @@ class Readme_Check implements themecheck {
 				);
 				$ret = false;
 			}
-	
+
 			// Warnings.
 			if ( isset( $readme->warnings['requires_header_ignored'] ) ) {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-warning">%s</span>: %s',
 					__( 'README WARNING', 'theme-check' ),
-						/* translators: 1: theme header tag; 2: Example version 5.0. 3: Example version 4.9. */
+					/* translators: 1: theme header tag; 2: Example version 5.0. 3: Example version 4.9. */
 					sprintf(
 						__( 'The %1$s field in the readme was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'theme-check' ),
 						'<code>Requires at least</code>',
@@ -86,7 +86,7 @@ class Readme_Check implements themecheck {
 					'<span class="tc-lead tc-warning">%s</span>: %s',
 					__( 'README WARNING', 'theme-check' ),
 					sprintf(
-						/* translators: %s: plugin header tag */
+						/* translators: %s: theme header tag */
 						__( 'The %s field is missing from the readme.', 'theme-check' ),
 						'<code>Requires at least</code>'
 					)
@@ -108,12 +108,12 @@ class Readme_Check implements themecheck {
 			} elseif ( empty( $readme->tested ) ) {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-warning">%s</span>: %s',
-						__( 'README WARNING', 'theme-check' ),
-						sprintf(
-							/* translators: %s: plugin header tag */
-							__( 'The %s field is missing from the readme file.', 'wporg-plugins' ),
-							'<code>Tested up to</code>'
-						)
+					__( 'README WARNING', 'theme-check' ),
+					sprintf(
+						/* translators: %s: plugin header tag */
+						__( 'The %s field is missing from the readme.', 'theme-check' ),
+						'<code>Tested up to</code>'
+					)
 				);
 			}
 
@@ -129,7 +129,7 @@ class Readme_Check implements themecheck {
 						'<code>7.0</code>'
 					)
 				);
-			} else if ( empty( $readme->requires_php ) ) {
+			} elseif ( empty( $readme->requires_php ) ) {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-warning">%s</span>: %s',
 					__( 'README WARNING', 'theme-check' ),
@@ -223,7 +223,6 @@ class Readme_Check implements themecheck {
 					)
 				);
 			}
-
 		}
 	}
 

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -29,7 +29,13 @@ class Readme_Check implements themecheck {
 		 *
 		 * @var string $latest_wordpress_version
 		 */
-		$latest_wordpress_version = '5.8';
+		if ( defined( 'WP_CORE_LATEST_RELEASE' ) ) {
+			// When running on WordPress.org, this constant defines the latest WordPress release.
+			$latest_wordpress_version = WP_CORE_LATEST_RELEASE;
+		} else {
+			// Assume that the local environment being tested in is up to date.
+			$latest_wordpress_version = $GLOBALS['wp_version'];
+		}
 
 		checkcount();
 

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -8,12 +8,26 @@
  */
 
 class Readme_Check implements themecheck {
+	
 	/**
 	 * Error messages, warnings and info notices.
 	 *
 	 * @var array $error
 	 */
 	protected $error = array();
+	
+	/**
+	 * Theme information. Author URI, theme URI, Author name
+	 *
+	 * @var object $theme
+	 */
+	protected $theme;
+
+	function set_context( $data ) {
+		if ( isset( $data['theme'] ) ) {
+			$this->theme = $data['theme'];
+		}
+	}
 
 	/**
 	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
@@ -61,7 +75,7 @@ class Readme_Check implements themecheck {
 			// Parse the content of the readme.
 			$readme = new Readme_Parser( $readme );
 
-			// Error.
+			// Error if the theme name is missing in the readme.
 			if ( empty( $readme->name ) ) {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-required">%s</span>: %s',
@@ -69,6 +83,20 @@ class Readme_Check implements themecheck {
 					/* translators: 1: 'Theme Name' section title, 2: 'Theme Name' */
 					sprintf(
 						__( 'Could not find a theme name in the readme. Theme name format looks like: %1$s. Please change %2$s to reflect the actual name of your theme.', 'theme-check' ),
+						'<code>=== Theme Name ===</code>',
+						'<code>Theme Name</code>'
+					)
+				);
+				$ret = false;
+			} else if ( $readme->name != $this->theme ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-required">%s</span>: %s',
+					__( 'README ERROR', 'theme-check' ),
+					/* translators: 1: actual theme name, 2: theme name in readme, 3: 'Theme Name' section title, 4: 'Theme Name' */
+					sprintf(
+						__( 'The theme name in the readme %1$s does not match the name of your theme %2$s. Theme name format looks like: %3$s. Please change %4$s to reflect the actual name of your theme.', 'theme-check' ),
+						'<code>' .  esc_html( $readme->name ) . '</code>',
+						'<code>' . esc_html( $this->theme ) . '</code>',
 						'<code>=== Theme Name ===</code>',
 						'<code>Theme Name</code>'
 					)

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -8,14 +8,14 @@
  */
 
 class Readme_Check implements themecheck {
-	
+
 	/**
 	 * Error messages, warnings and info notices.
 	 *
 	 * @var array $error
 	 */
 	protected $error = array();
-	
+
 	/**
 	 * Theme information. Author URI, theme URI, Author name
 	 *
@@ -88,14 +88,14 @@ class Readme_Check implements themecheck {
 					)
 				);
 				$ret = false;
-			} else if ( $readme->name != $this->theme ) {
+			} elseif ( $readme->name != $this->theme ) {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-required">%s</span>: %s',
 					__( 'README ERROR', 'theme-check' ),
 					/* translators: 1: actual theme name, 2: theme name in readme, 3: 'Theme Name' section title, 4: 'Theme Name' */
 					sprintf(
 						__( 'The theme name in the readme %1$s does not match the name of your theme %2$s. Theme name format looks like: %3$s. Please change %4$s to reflect the actual name of your theme.', 'theme-check' ),
-						'<code>' .  esc_html( $readme->name ) . '</code>',
+						'<code>' . esc_html( $readme->name ) . '</code>',
 						'<code>' . esc_html( $this->theme ) . '</code>',
 						'<code>=== Theme Name ===</code>',
 						'<code>Theme Name</code>'

--- a/checks/class-readme-check.php
+++ b/checks/class-readme-check.php
@@ -2,6 +2,8 @@
 /**
  * Validate readme files.
  *
+ * @link https://meta.svn.wordpress.org/sites/trunk/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/
+ *
  * @package Theme Check
  */
 

--- a/checks/class-readme-parser.php
+++ b/checks/class-readme-parser.php
@@ -167,6 +167,7 @@ class Readme_Parser {
 		} else {
 			$contents = preg_split( '!\R!', $contents ); // regex failed due to invalid UTF8 in $contents, see #2298
 		}
+		// Remove empty lines.
 		$contents = array_map( array( $this, 'strip_newlines' ), $contents );
 
 		// Strip UTF8 BOM if present.
@@ -180,6 +181,8 @@ class Readme_Parser {
 				$contents[ $i ] = mb_convert_encoding( $line, 'UTF-8', 'UTF-16' );
 			}
 		}
+
+		$contents = array_filter( $contents, 'strlen' ); 
 
 		$line       = $this->get_first_nonwhitespace( $contents );
 		$this->name = $this->sanitize_text( trim( $line, "#= \t\0\x0B" ) );
@@ -329,7 +332,18 @@ class Readme_Parser {
 	 */
 	protected function sanitize_tested_version( $version ) {
 		$version                  = trim( $version );
-		$latest_wordpress_version = '5.8';
+		/**
+		 * Latest WordPress version
+		 *
+		 * @var string $latest_wordpress_version
+		 */
+		if ( defined( 'WP_CORE_LATEST_RELEASE' ) ) {
+			// When running on WordPress.org, this constant defines the latest WordPress release.
+			$latest_wordpress_version = WP_CORE_LATEST_RELEASE;
+		} else {
+			// Assume that the local environment being tested in is up to date.
+			$latest_wordpress_version = $GLOBALS['wp_version'];
+		}
 
 		if ( $version ) {
 			// Handle the edge-case of 'WordPress 5.0' and 'WP 5.0' for historical purposes.

--- a/checks/class-readme-parser.php
+++ b/checks/class-readme-parser.php
@@ -7,66 +7,92 @@
 class Readme_Parser {
 
 	/**
+	 * Theme name
+	 *
 	 * @var string
 	 */
 	public $name = '';
 
 	/**
+	 * Theme tags
+	 *
 	 * @var array
 	 */
 	public $tags = array();
 
 	/**
+	 * Minimum WordPress version
+	 *
 	 * @var string
 	 */
 	public $requires = '';
 
 	/**
+	 * Tested up to
+	 *
 	 * @var string
 	 */
 	public $tested = '';
 
 	/**
+	 * Requires PHP
+	 *
 	 * @var string
 	 */
 	public $requires_php = '';
 
 	/**
+	 * Contributors, a WordPress.org username.
+	 *
 	 * @var array
 	 */
 	public $contributors = array();
 
 	/**
+	 * Donation link
+	 *
 	 * @var string
 	 */
 	public $donate_link = '';
 
 	/**
+	 * Readme short description
+	 *
 	 * @var string
 	 */
 	public $short_description = '';
 
 	/**
+	 * Theme license
+	 *
 	 * @var string
 	 */
 	public $license = '';
 
 	/**
+	 * Theme license URI
+	 *
 	 * @var string
 	 */
 	public $license_uri = '';
 
 	/**
+	 * Readme sections
+	 *
 	 * @var array
 	 */
 	public $sections = array();
 
 	/**
+	 * Theme upgrade notice
+	 *
 	 * @var array
 	 */
 	public $upgrade_notice = array();
 
 	/**
+	 * Theme FAQ
+	 *
 	 * @var array
 	 */
 	public $faq = array();
@@ -124,13 +150,14 @@ class Readme_Parser {
 	 * Parser constructor.
 	 *
 	 * @param string $string Contents of a readme to parse.
-	 *
 	 */
 	public function __construct( $string ) {
 		$this->parse_readme_contents( $string );
 	}
 
 	/**
+	 * Parse and sanitize the readme
+	 *
 	 * @param string $contents The contents of the readme to parse.
 	 * @return bool
 	 */
@@ -227,9 +254,11 @@ class Readme_Parser {
 	}
 
 	/**
+	 * Get the first non white space in the readme file content
+	 *
 	 * @access protected
 	 *
-	 * @param string $contents
+	 * @param string $contents Readme file content.
 	 * @return string
 	 */
 	protected function get_first_nonwhitespace( &$contents ) {
@@ -244,9 +273,11 @@ class Readme_Parser {
 	}
 
 	/**
+	 * Strip new lines
+	 *
 	 * @access protected
 	 *
-	 * @param string $line
+	 * @param string $line The line to remove the line endings from.
 	 * @return string
 	 */
 	protected function strip_newlines( $line ) {
@@ -254,13 +285,14 @@ class Readme_Parser {
 	}
 
 	/**
+	 * Sanitize and remove characters from the theme name
+	 *
 	 * @access protected
 	 *
-	 * @param string $text
+	 * @param string $text Text to sanitize.
 	 * @return string
 	 */
 	protected function sanitize_text( $text ) {
-		// not fancy
 		$text = strip_tags( $text );
 		$text = esc_html( $text );
 		$text = trim( $text );
@@ -269,9 +301,9 @@ class Readme_Parser {
 	}
 
 	/**
-	 * Sanitizes the Requires PHP header to ensure that it's a valid version header.
+	 * Sanitizes the Requires PHP header to ensure that it's a valid version header
 	 *
-	 * @param string $version
+	 * @param string $version Minimum required PHP version.
 	 * @return string The sanitized $version
 	 */
 	protected function sanitize_requires_php( $version ) {
@@ -288,23 +320,22 @@ class Readme_Parser {
 	}
 
 	/**
-	 * Sanitizes the Tested header to ensure that it's a valid version header.
+	 * Sanitizes the Tested header to ensure that it's a valid version header
 	 *
-	 * @param string $version
+	 * @param string $version WordPress version that the theme is tested with.
 	 * @return string The sanitized $version
 	 */
 	protected function sanitize_tested_version( $version ) {
-		$version = trim( $version );
+		$version                  = trim( $version );
 		$latest_wordpress_version = '5.8';
 
 		if ( $version ) {
-
 			// Handle the edge-case of 'WordPress 5.0' and 'WP 5.0' for historical purposes.
 			$strip_phrases = [
 				'WordPress',
 				'WP',
 			];
-			$version = trim( str_ireplace( $strip_phrases, '', $version ) );
+			$version       = trim( str_ireplace( $strip_phrases, '', $version ) );
 
 			// Strip off any -alpha, -RC, -beta suffixes, as these complicate comparisons and are rarely used.
 			list( $version, ) = explode( '-', $version );
@@ -315,9 +346,9 @@ class Readme_Parser {
 				// Allow themes to mark themselves as compatible with Stable+0.1 (trunk/master) but not higher
 				(
 					$latest_wordpress_version &&
-					version_compare( (float)$version, (float)$latest_wordpress_version+0.1, '>' )
+					version_compare( (float) $version, (float) $latest_wordpress_version + 0.1, '>' )
 				)
-			 ) {
+			) {
 				$this->warnings['tested_header_ignored'] = true;
 				// Ignore the readme value.
 				$version = '';
@@ -328,16 +359,16 @@ class Readme_Parser {
 	}
 
 	/**
-	 * Sanitizes the Requires at least header to ensure that it's a valid version header.
+	 * Sanitizes the Requires at least header to ensure that it's a valid version header
 	 *
-	 * @param string $version
+	 * @param string $version The minim required WordPress version.
 	 * @return string The sanitized $version
 	 */
 	protected function sanitize_requires_version( $version ) {
-		$version = trim( $version );
+		$version                  = trim( $version );
 		$latest_wordpress_version = '5.9';
-		if ( $version ) {
 
+		if ( $version ) {
 			// Handle the edge-case of 'WordPress 5.0' and 'WP 5.0' for historical purposes.
 			$strip_phrases = [
 				'WordPress',
@@ -346,8 +377,8 @@ class Readme_Parser {
 				'and above',
 				'+',
 			];
-			$version = trim( str_ireplace( $strip_phrases, '', $version ) );
-			
+			$version       = trim( str_ireplace( $strip_phrases, '', $version ) );
+
 			// Strip off any -alpha, -RC, -beta suffixes, as these complicate comparisons and are rarely used.
 			list( $version, ) = explode( '-', $version );
 
@@ -355,8 +386,8 @@ class Readme_Parser {
 				// x.y or x.y.z
 				! preg_match( '!^\d+\.\d(\.\d+)?$!', $version ) ||
 				// Allow themes to mark themselves as requireing Stable+0.1 (trunk/master) but not higher
-				$latest_wordpress_version && ( (float)$version > (float)$latest_wordpress_version+0.1 )
-			 ) {
+				$latest_wordpress_version && ( (float) $version > (float) $latest_wordpress_version + 0.1 )
+			) {
 				$this->warnings['requires_header_ignored'] = true;
 				// Ignore the readme value.
 				$version = '';

--- a/checks/class-readme-parser.php
+++ b/checks/class-readme-parser.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * Readme Parser.
+ *
+ * @package Theme Check
+ */
+class Readme_Parser {
+
+	/**
+	 * @var string
+	 */
+	public $name = '';
+
+	/**
+	 * @var array
+	 */
+	public $tags = array();
+
+	/**
+	 * @var string
+	 */
+	public $requires = '';
+
+	/**
+	 * @var string
+	 */
+	public $tested = '';
+
+	/**
+	 * @var string
+	 */
+	public $requires_php = '';
+
+	/**
+	 * @var array
+	 */
+	public $contributors = array();
+
+	/**
+	 * @var string
+	 */
+	public $donate_link = '';
+
+	/**
+	 * @var string
+	 */
+	public $short_description = '';
+
+	/**
+	 * @var string
+	 */
+	public $license = '';
+
+	/**
+	 * @var string
+	 */
+	public $license_uri = '';
+
+	/**
+	 * @var array
+	 */
+	public $sections = array();
+
+	/**
+	 * @var array
+	 */
+	public $upgrade_notice = array();
+
+	/**
+	 * @var array
+	 */
+	public $faq = array();
+
+	/**
+	 * Warning flags which indicate specific parsing failures have occured.
+	 *
+	 * @var array
+	 */
+	public $warnings = array();
+
+	/**
+	 * These are the readme sections that we expect.
+	 *
+	 * @var array
+	 */
+	private $expected_sections = array(
+		'description',
+		'installation',
+		'faq',
+		'changelog',
+		'upgrade_notice',
+		'other_notes',
+	);
+
+	/**
+	 * We alias these sections, from => to
+	 *
+	 * @var array
+	 */
+	private $alias_sections = array(
+		'frequently_asked_questions' => 'faq',
+		'change_log'                 => 'changelog',
+	);
+
+	/**
+	 * These are the valid header mappings for the header.
+	 *
+	 * @var array
+	 */
+	private $valid_headers = array(
+		'tested'            => 'tested',
+		'tested up to'      => 'tested',
+		'requires'          => 'requires',
+		'requires at least' => 'requires',
+		'requires php'      => 'requires_php',
+		'tags'              => 'tags',
+		'contributors'      => 'contributors',
+		'donate link'       => 'donate_link',
+		'license'           => 'license',
+		'license uri'       => 'license_uri',
+	);
+
+	/**
+	 * Parser constructor.
+	 *
+	 * @param string $string Contents of a readme to parse.
+	 *
+	 */
+	public function __construct( $string ) {
+		$this->parse_readme_contents( $string );
+	}
+
+	/**
+	 * @param string $contents The contents of the readme to parse.
+	 * @return bool
+	 */
+	protected function parse_readme_contents( $contents ) {
+		if ( preg_match( '!!u', $contents ) ) {
+			$contents = preg_split( '!\R!u', $contents );
+		} else {
+			$contents = preg_split( '!\R!', $contents ); // regex failed due to invalid UTF8 in $contents, see #2298
+		}
+		$contents = array_map( array( $this, 'strip_newlines' ), $contents );
+
+		// Strip UTF8 BOM if present.
+		if ( 0 === strpos( $contents[0], "\xEF\xBB\xBF" ) ) {
+			$contents[0] = substr( $contents[0], 3 );
+		}
+
+		// Convert UTF-16 files.
+		if ( 0 === strpos( $contents[0], "\xFF\xFE" ) ) {
+			foreach ( $contents as $i => $line ) {
+				$contents[ $i ] = mb_convert_encoding( $line, 'UTF-8', 'UTF-16' );
+			}
+		}
+
+		$line       = $this->get_first_nonwhitespace( $contents );
+		$this->name = $this->sanitize_text( trim( $line, "#= \t\0\x0B" ) );
+
+		// Strip Github style header\n==== underlines.
+		if ( ! empty( $contents ) && '' === trim( $contents[0], '=-' ) ) {
+			array_shift( $contents );
+		}
+
+		// Handle readme's which do `=== Theme Name ===\nMy SuperAwesome Name\n...`
+		if ( 'theme name' == strtolower( $this->name ) ) {
+			$this->name = $line = $this->get_first_nonwhitespace( $contents );
+
+			// Ensure that the line read wasn't an actual header or description.
+			if ( strlen( $line ) > 50 || preg_match( '~^(' . implode( '|', array_keys( $this->valid_headers ) ) . ')\s*:~i', $line ) ) {
+				$this->name = false;
+				array_unshift( $contents, $line );
+			}
+		}
+
+		// Parse headers.
+		$headers = array();
+
+		$line = $this->get_first_nonwhitespace( $contents );
+		do {
+			$value = null;
+			if ( false === strpos( $line, ':' ) ) {
+
+				// Some themes have line-breaks within the headers.
+				if ( empty( $line ) ) {
+					break;
+				} else {
+					continue;
+				}
+			}
+
+			$bits                = explode( ':', trim( $line ), 2 );
+			list( $key, $value ) = $bits;
+			$key                 = strtolower( trim( $key, " \t*-\r\n" ) );
+			if ( isset( $this->valid_headers[ $key ] ) ) {
+				$headers[ $this->valid_headers[ $key ] ] = trim( $value );
+			}
+		} while ( ( $line = array_shift( $contents ) ) !== null );
+		array_unshift( $contents, $line );
+
+		if ( ! empty( $headers['requires'] ) ) {
+			$this->requires = $this->sanitize_requires_version( $headers['requires'] );
+		}
+		if ( ! empty( $headers['tested'] ) ) {
+			$this->tested = $this->sanitize_tested_version( $headers['tested'] );
+		}
+		if ( ! empty( $headers['requires_php'] ) ) {
+			$this->requires_php = $this->sanitize_requires_php( $headers['requires_php'] );
+		}
+		if ( ! empty( $headers['contributors'] ) ) {
+			$this->contributors = explode( ',', $headers['contributors'] );
+			$this->contributors = array_map( 'trim', $this->contributors );
+		}
+		if ( ! empty( $headers['license'] ) ) {
+			// Handle the many cases of "License: GPLv2 - http://..."
+			if ( empty( $headers['license_uri'] ) && preg_match( '!(https?://\S+)!i', $headers['license'], $url ) ) {
+				$headers['license_uri'] = $url[1];
+				$headers['license']     = trim( str_replace( $url[1], '', $headers['license'] ), " -*\t\n\r\n" );
+			}
+			$this->license = $headers['license'];
+		}
+		if ( ! empty( $headers['license_uri'] ) ) {
+			$this->license_uri = $headers['license_uri'];
+		}
+
+		return true;
+	}
+
+	/**
+	 * @access protected
+	 *
+	 * @param string $contents
+	 * @return string
+	 */
+	protected function get_first_nonwhitespace( &$contents ) {
+		while ( ( $line = array_shift( $contents ) ) !== null ) {
+			$trimmed = trim( $line );
+			if ( ! empty( $trimmed ) ) {
+				break;
+			}
+		}
+
+		return $line;
+	}
+
+	/**
+	 * @access protected
+	 *
+	 * @param string $line
+	 * @return string
+	 */
+	protected function strip_newlines( $line ) {
+		return rtrim( $line, "\r\n" );
+	}
+
+	/**
+	 * @access protected
+	 *
+	 * @param string $text
+	 * @return string
+	 */
+	protected function sanitize_text( $text ) {
+		// not fancy
+		$text = strip_tags( $text );
+		$text = esc_html( $text );
+		$text = trim( $text );
+
+		return $text;
+	}
+
+	/**
+	 * Sanitizes the Requires PHP header to ensure that it's a valid version header.
+	 *
+	 * @param string $version
+	 * @return string The sanitized $version
+	 */
+	protected function sanitize_requires_php( $version ) {
+		$version = trim( $version );
+
+		// x.y or x.y.z
+		if ( $version && ! preg_match( '!^\d+(\.\d+){1,2}$!', $version ) ) {
+			$this->warnings['requires_php_header_ignored'] = true;
+			// Ignore the readme value.
+			$version = '';
+		}
+
+		return $version;
+	}
+
+	/**
+	 * Sanitizes the Tested header to ensure that it's a valid version header.
+	 *
+	 * @param string $version
+	 * @return string The sanitized $version
+	 */
+	protected function sanitize_tested_version( $version ) {
+		$version = trim( $version );
+		$latest_wordpress_version = '5.8';
+
+		if ( $version ) {
+
+			// Handle the edge-case of 'WordPress 5.0' and 'WP 5.0' for historical purposes.
+			$strip_phrases = [
+				'WordPress',
+				'WP',
+			];
+			$version = trim( str_ireplace( $strip_phrases, '', $version ) );
+
+			// Strip off any -alpha, -RC, -beta suffixes, as these complicate comparisons and are rarely used.
+			list( $version, ) = explode( '-', $version );
+
+			if (
+				// x.y or x.y.z
+				! preg_match( '!^\d+\.\d(\.\d+)?$!', $version ) ||
+				// Allow themes to mark themselves as compatible with Stable+0.1 (trunk/master) but not higher
+				(
+					$latest_wordpress_version &&
+					version_compare( (float)$version, (float)$latest_wordpress_version+0.1, '>' )
+				)
+			 ) {
+				$this->warnings['tested_header_ignored'] = true;
+				// Ignore the readme value.
+				$version = '';
+			}
+		}
+
+		return $version;
+	}
+
+	/**
+	 * Sanitizes the Requires at least header to ensure that it's a valid version header.
+	 *
+	 * @param string $version
+	 * @return string The sanitized $version
+	 */
+	protected function sanitize_requires_version( $version ) {
+		$version = trim( $version );
+		$latest_wordpress_version = '5.9';
+		if ( $version ) {
+
+			// Handle the edge-case of 'WordPress 5.0' and 'WP 5.0' for historical purposes.
+			$strip_phrases = [
+				'WordPress',
+				'WP',
+				'or higher',
+				'and above',
+				'+',
+			];
+			$version = trim( str_ireplace( $strip_phrases, '', $version ) );
+			
+			// Strip off any -alpha, -RC, -beta suffixes, as these complicate comparisons and are rarely used.
+			list( $version, ) = explode( '-', $version );
+
+			if (
+				// x.y or x.y.z
+				! preg_match( '!^\d+\.\d(\.\d+)?$!', $version ) ||
+				// Allow themes to mark themselves as requireing Stable+0.1 (trunk/master) but not higher
+				$latest_wordpress_version && ( (float)$version > (float)$latest_wordpress_version+0.1 )
+			 ) {
+				$this->warnings['requires_header_ignored'] = true;
+				// Ignore the readme value.
+				$version = '';
+			}
+		}
+
+		return $version;
+	}
+
+}

--- a/checks/class-readme-parser.php
+++ b/checks/class-readme-parser.php
@@ -182,7 +182,7 @@ class Readme_Parser {
 			}
 		}
 
-		$contents = array_filter( $contents, 'strlen' ); 
+		$contents   = array_filter( $contents, 'strlen' ); 
 
 		$line       = $this->get_first_nonwhitespace( $contents );
 		$this->name = $this->sanitize_text( trim( $line, "#= \t\0\x0B" ) );
@@ -331,7 +331,8 @@ class Readme_Parser {
 	 * @return string The sanitized $version
 	 */
 	protected function sanitize_tested_version( $version ) {
-		$version                  = trim( $version );
+		$version = trim( $version );
+
 		/**
 		 * Latest WordPress version
 		 *

--- a/checks/class-readme-parser.php
+++ b/checks/class-readme-parser.php
@@ -182,7 +182,7 @@ class Readme_Parser {
 			}
 		}
 
-		$contents   = array_filter( $contents, 'strlen' ); 
+		$contents = array_filter( $contents, 'strlen' );
 
 		$line       = $this->get_first_nonwhitespace( $contents );
 		$this->name = $this->sanitize_text( trim( $line, "#= \t\0\x0B" ) );

--- a/checks/class-readme-parser.php
+++ b/checks/class-readme-parser.php
@@ -192,7 +192,7 @@ class Readme_Parser {
 		// Handle readme's which do `=== Theme Name ===\nMy SuperAwesome Name\n...`
 		if ( 'theme name' == strtolower( $this->name ) ) {
 
-			$line = $this->get_first_nonwhitespace( $contents );
+			$line       = $this->get_first_nonwhitespace( $contents );
 			$this->name = $line;
 
 			// Ensure that the line read wasn't an actual header or description.

--- a/checks/class-readme-parser.php
+++ b/checks/class-readme-parser.php
@@ -293,7 +293,7 @@ class Readme_Parser {
 	 * @return string
 	 */
 	protected function sanitize_text( $text ) {
-		$text = strip_tags( $text );
+		$text = wp_strip_all_tags( $text );
 		$text = esc_html( $text );
 		$text = trim( $text );
 
@@ -331,10 +331,7 @@ class Readme_Parser {
 
 		if ( $version ) {
 			// Handle the edge-case of 'WordPress 5.0' and 'WP 5.0' for historical purposes.
-			$strip_phrases = [
-				'WordPress',
-				'WP',
-			];
+			$strip_phrases = array( 'WordPress', 'WP' );
 			$version       = trim( str_ireplace( $strip_phrases, '', $version ) );
 
 			// Strip off any -alpha, -RC, -beta suffixes, as these complicate comparisons and are rarely used.
@@ -370,13 +367,7 @@ class Readme_Parser {
 
 		if ( $version ) {
 			// Handle the edge-case of 'WordPress 5.0' and 'WP 5.0' for historical purposes.
-			$strip_phrases = [
-				'WordPress',
-				'WP',
-				'or higher',
-				'and above',
-				'+',
-			];
+			$strip_phrases = array( 'WordPress', 'WP', 'or higher', 'and above', '+' );
 			$version       = trim( str_ireplace( $strip_phrases, '', $version ) );
 
 			// Strip off any -alpha, -RC, -beta suffixes, as these complicate comparisons and are rarely used.

--- a/checks/class-readme-parser.php
+++ b/checks/class-readme-parser.php
@@ -191,7 +191,9 @@ class Readme_Parser {
 
 		// Handle readme's which do `=== Theme Name ===\nMy SuperAwesome Name\n...`
 		if ( 'theme name' == strtolower( $this->name ) ) {
-			$this->name = $line = $this->get_first_nonwhitespace( $contents );
+
+			$line = $this->get_first_nonwhitespace( $contents );
+			$this->name = $line;
 
 			// Ensure that the line read wasn't an actual header or description.
 			if ( strlen( $line ) > 50 || preg_match( '~^(' . implode( '|', array_keys( $this->valid_headers ) ) . ')\s*:~i', $line ) ) {


### PR DESCRIPTION
Fixes https://github.com/WordPress/theme-check/issues/375

This check and the accompanying parser is copied from the plugin readme validator.

It is more limited than the plugin readme validator, and it does not work for themes that are in sub folders.
The subfolder issue may be solved by #370. Untested.

**How to test:**

1. Test with a theme that is missing a readme.txt and readme.md
2. Confirm that the error about the missing readme is displaying.
3. Test with a theme with missing headers in the readme.
4. Confirm that the warnings are displaying.
5. Test with a theme with incorrect headers in the readme.
6. Confirm that the warnings are displaying.

