### PR TITLE
Added Template Editing tag in allowed tags list

### DIFF
--- a/checks/class-style-tags-check.php
+++ b/checks/class-style-tags-check.php
@@ -169,6 +169,7 @@ class Style_Tags_Check implements themecheck {
 			'post-formats',
 			'rtl-language-support',
 			'sticky-post',
+			'template-editing',
 			'theme-options',
 			'threaded-comments',
 			'translation-ready',


### PR DESCRIPTION
Template Editing is a new tag and added in WordPress.  Current version of Theme checks show it as REQUIRED.