### PR TITLE
Update class-plugin-territory-check.php

### DIFF
--- a/checks/class-plugin-territory-check.php
+++ b/checks/class-plugin-territory-check.php
@@ -27,43 +27,15 @@ class Plugin_Territory_Check implements themecheck {
 	 */
 	public function check( $php_files, $css_files, $other_files ) {
 		$ret = true;
-		$php = implode( ' ', $php_files );
 
 		// Functions that are required to be removed from the theme.
 		$forbidden_functions = array(
 			'register_post_type',
 			'register_taxonomy',
 			'register_block_type',
+			'add_role',
+			'add_shortcode',
 		);
-
-		foreach ( $forbidden_functions as $function ) {
-			checkcount();
-			if ( preg_match( '/[\s?]' . $function . '\s?\(/', $php ) ) {
-				$this->error[] = sprintf(
-					'<span class="tc-lead tc-required">%s</span> %s',
-					__( 'REQUIRED', 'theme-check' ),
-					sprintf(
-						__( 'The theme uses the %s function, which is plugin-territory functionality.', 'theme-check' ),
-						'<strong>' . esc_html( $function ) . '()</strong>'
-					)
-				);
-				$ret           = false;
-			}
-		}
-
-		// Shortcodes can't be used in the post content, so warn about them.
-		if ( false !== strpos( $php, 'add_shortcode(' ) ) {
-			checkcount();
-			$this->error[] = sprintf(
-				'<span class="tc-lead tc-required">%s</span> %s',
-				__( 'REQUIRED', 'theme-check' ),
-				sprintf(
-					__( 'The theme uses the %s function. Custom shortcodes are plugin-territory functionality.', 'theme-check' ),
-					'<strong>add_shortcode()</strong>'
-				)
-			);
-			$ret           = false;
-		}
 
 		// Hooks (actions & filters) that are required to be removed from the theme.
 		$forbidden_hooks = array(
@@ -74,34 +46,14 @@ class Plugin_Territory_Check implements themecheck {
 			),
 		);
 
-		foreach ( $forbidden_hooks as $type => $hooks ) {
-			foreach ( $hooks as $hook ) {
-				checkcount();
-				if ( preg_match( '/[\s?]add_' . $type . '\s*\(\s*([\'"])' . $hook . '([\'"])\s*,/', $php ) ) {
-					$this->error[] = sprintf(
-						'<span class="tc-lead tc-required">%s</span>: %s',
-						__( 'REQUIRED', 'theme-check' ),
-						sprintf(
-							__( 'The theme uses the %1$s %2$s, which is plugin-territory functionality.', 'theme-check' ),
-							'<strong>' . esc_html( $hook ) . '</strong>',
-							esc_html( $type )
-						)
-					);
-					$ret           = false;
-				}
-			}
-		}
-
 		/**
 		 * Check for removal of non presentational hooks.
-		 * Removing emojis is also not allowed.
 		 */
 		$blocklist = array(
 			'wp_head'             => array(
 				'wp_generator', // @link https://developer.wordpress.org/reference/functions/wp_generator/
 				'feed_links', // @link https://developer.wordpress.org/reference/functions/feed_links/
 				'feed_links_extra', // @link https://developer.wordpress.org/reference/functions/feed_links_extra/
-				'print_emoji_detection_script', // @link https://developer.wordpress.org/reference/functions/print_emoji_detection_script/
 				'wp_resource_hints', // @link https://developer.wordpress.org/reference/functions/wp_resource_hints/
 				'adjacent_posts_rel_link_wp_head', // @link https://developer.wordpress.org/reference/functions/adjacent_posts_rel_link_wp_head/
 				'wp_shortlink_wp_head', // @link https://developer.wordpress.org/reference/functions/wp_shortlink_wp_head/
@@ -112,15 +64,6 @@ class Plugin_Territory_Check implements themecheck {
 				'wp_oembed_add_host_js', // @link https://developer.wordpress.org/reference/functions/wp_oembed_add_host_js/
 				'rel_canonical', // @link https://developer.wordpress.org/reference/functions/rel_canonical/
 			),
-			'wp_print_styles'     => array(
-				'print_emoji_styles', // @link https://developer.wordpress.org/reference/functions/print_emoji_styles/
-			),
-			'admin_print_scripts' => array(
-				'print_emoji_detection_script', // @link https://developer.wordpress.org/reference/functions/print_emoji_detection_script/
-			),
-			'admin_print_styles'  => array(
-				'print_emoji_styles', // @link https://developer.wordpress.org/reference/functions/print_emoji_styles/
-			),
 			'template_redirect'   => array(
 				'rest_output_link_header', // @link https://developer.wordpress.org/reference/functions/rest_output_link_header/
 				'wp_shortlink_header', // @link https://developer.wordpress.org/reference/functions/wp_shortlink_header/
@@ -128,20 +71,68 @@ class Plugin_Territory_Check implements themecheck {
 			),
 		);
 
-		foreach ( $blocklist as $hook => $functions ) {
-			foreach ( $functions as $function ) {
+		foreach ( $php_files as $php_key => $phpfile ) {
+
+			foreach ( $forbidden_functions as $function ) {
 				checkcount();
-				if ( preg_match( '/[\s?]remove_action\s*\(\s*([\'"])' . $hook . '([\'"])\s*,\s*([\'"])' . $function . '([\'"])/', $php ) ) {
+				if ( preg_match( '/[\s?]' . $function . '\s?\(/', $phpfile ) ) {
+					$filename     = tc_filename( $php_key );
+					$grep          = tc_grep( $function, $php_key );
 					$this->error[] = sprintf(
 						'<span class="tc-lead tc-required">%s</span> %s',
 						__( 'REQUIRED', 'theme-check' ),
 						sprintf(
-							__( 'The theme uses <strong>remove_action %1$s %2$s</strong>, which is plugin-territory functionality.', 'theme-check' ),
-							esc_html( $hook ),
-							esc_html( $function )
+							__( 'The theme uses the %1$s function in the file %2$s. %1$s is plugin-territory functionality and must not be used in themes. Use a plugin instead. %3$s', 'theme-check' ),
+							'<strong>' . esc_html( $function ) . '()</strong>',
+							'<strong>' . esc_html( $filename ) . '</strong>',
+							$grep
 						)
 					);
 					$ret           = false;
+				}
+			}
+
+			foreach ( $forbidden_hooks as $type => $hooks ) {
+				foreach ( $hooks as $hook ) {
+					$filename     = tc_filename( $php_key );
+					$grep         = tc_grep( $hook, $php_key );
+					checkcount();
+					if ( preg_match( '/[\s?]add_' . $type . '\s*\(\s*([\'"])' . $hook . '([\'"])\s*,/', $phpfile ) ) {
+						$this->error[] = sprintf(
+							'<span class="tc-lead tc-required">%s</span>: %s',
+							__( 'REQUIRED', 'theme-check' ),
+							sprintf(
+								__( 'The theme uses the %1$s %2$s in the file %3$s. This is plugin-territory functionality. Use a plugin instead. %4$s', 'theme-check' ),
+								'<strong>' . esc_html( $hook ) . '</strong>',
+								esc_html( $type ),
+								$filename,
+								$grep
+							)
+						);
+						$ret           = false;
+					}
+				}
+			}
+
+			foreach ( $blocklist as $hook => $functions ) {
+				foreach ( $functions as $function ) {
+					checkcount();
+					if ( preg_match( '/[\s?]remove_action\s*\(\s*([\'"])' . $hook . '([\'"])\s*,\s*([\'"])' . $function . '([\'"])/', $phpfile ) ) {
+						$filename      = tc_filename( $php_key );
+						$grep          = tc_preg( '/' . $hook . '([\'"])\s*,\s*([\'"])' . $function . '([\'"])/', $php_key );
+						$this->error[] = sprintf(
+							'<span class="tc-lead tc-required">%s</span> %s',
+							__( 'REQUIRED', 'theme-check' ),
+							sprintf(
+								__( 'The theme uses <strong>remove_action %1$s %2$s</strong> in the file %3$s. This is plugin-territory functionality. Use a plugin instead. %4$s', 'theme-check' ),
+								esc_html( $hook ),
+								esc_html( $function ),
+								$filename,
+								$grep
+							)
+						);
+						$ret           = false;
+					}
 				}
 			}
 		}

--- a/checks/class-plugin-territory-check.php
+++ b/checks/class-plugin-territory-check.php
@@ -79,12 +79,12 @@ class Plugin_Territory_Check implements themecheck {
 					$filename      = tc_filename( $php_key );
 					$grep          = tc_grep( $function, $php_key );
 					$this->error[] = sprintf(
-						'<span class="tc-lead tc-required">%s</span> %s',
+						'<span class="tc-lead tc-required">%s</span>: %s',
 						__( 'REQUIRED', 'theme-check' ),
 						sprintf(
 							__( 'The theme uses the %1$s function in the file %2$s. %1$s is plugin-territory functionality and must not be used in themes. Use a plugin instead. %3$s', 'theme-check' ),
 							'<strong>' . esc_html( $function ) . '()</strong>',
-							'<strong>' . esc_html( $filename ) . '</strong>',
+							esc_html( $filename ),
 							$grep
 						)
 					);
@@ -102,7 +102,7 @@ class Plugin_Territory_Check implements themecheck {
 							'<span class="tc-lead tc-required">%s</span>: %s',
 							__( 'REQUIRED', 'theme-check' ),
 							sprintf(
-								__( 'The theme uses the %1$s %2$s in the file %3$s. This is plugin-territory functionality. Use a plugin instead. %4$s', 'theme-check' ),
+								__( 'The theme uses the %1$s %2$s in the file %3$s. This is plugin-territory functionality and must not be used in themes. Use a plugin instead. %4$s', 'theme-check' ),
 								'<strong>' . esc_html( $hook ) . '</strong>',
 								esc_html( $type ),
 								$filename,
@@ -121,10 +121,10 @@ class Plugin_Territory_Check implements themecheck {
 						$filename      = tc_filename( $php_key );
 						$grep          = tc_preg( '/' . $hook . '([\'"])\s*,\s*([\'"])' . $function . '([\'"])/', $php_key );
 						$this->error[] = sprintf(
-							'<span class="tc-lead tc-required">%s</span> %s',
+							'<span class="tc-lead tc-required">%s</span>: %s',
 							__( 'REQUIRED', 'theme-check' ),
 							sprintf(
-								__( 'The theme uses <strong>remove_action %1$s %2$s</strong> in the file %3$s. This is plugin-territory functionality. Use a plugin instead. %4$s', 'theme-check' ),
+								__( 'The theme uses <strong>remove_action %1$s %2$s</strong> in the file %3$s. This is plugin-territory functionality and must not be used in themes. Use a plugin instead. %4$s', 'theme-check' ),
 								esc_html( $hook ),
 								esc_html( $function ),
 								$filename,

--- a/checks/class-plugin-territory-check.php
+++ b/checks/class-plugin-territory-check.php
@@ -50,7 +50,7 @@ class Plugin_Territory_Check implements themecheck {
 		 * Check for removal of non presentational hooks.
 		 */
 		$blocklist = array(
-			'wp_head'             => array(
+			'wp_head'           => array(
 				'wp_generator', // @link https://developer.wordpress.org/reference/functions/wp_generator/
 				'feed_links', // @link https://developer.wordpress.org/reference/functions/feed_links/
 				'feed_links_extra', // @link https://developer.wordpress.org/reference/functions/feed_links_extra/
@@ -64,7 +64,7 @@ class Plugin_Territory_Check implements themecheck {
 				'wp_oembed_add_host_js', // @link https://developer.wordpress.org/reference/functions/wp_oembed_add_host_js/
 				'rel_canonical', // @link https://developer.wordpress.org/reference/functions/rel_canonical/
 			),
-			'template_redirect'   => array(
+			'template_redirect' => array(
 				'rest_output_link_header', // @link https://developer.wordpress.org/reference/functions/rest_output_link_header/
 				'wp_shortlink_header', // @link https://developer.wordpress.org/reference/functions/wp_shortlink_header/
 				'redirect_canonical',  // @link https://developer.wordpress.org/reference/functions/redirect_canonical/
@@ -76,7 +76,7 @@ class Plugin_Territory_Check implements themecheck {
 			foreach ( $forbidden_functions as $function ) {
 				checkcount();
 				if ( preg_match( '/[\s?]' . $function . '\s?\(/', $phpfile ) ) {
-					$filename     = tc_filename( $php_key );
+					$filename      = tc_filename( $php_key );
 					$grep          = tc_grep( $function, $php_key );
 					$this->error[] = sprintf(
 						'<span class="tc-lead tc-required">%s</span> %s',
@@ -94,10 +94,10 @@ class Plugin_Territory_Check implements themecheck {
 
 			foreach ( $forbidden_hooks as $type => $hooks ) {
 				foreach ( $hooks as $hook ) {
-					$filename     = tc_filename( $php_key );
-					$grep         = tc_grep( $hook, $php_key );
 					checkcount();
 					if ( preg_match( '/[\s?]add_' . $type . '\s*\(\s*([\'"])' . $hook . '([\'"])\s*,/', $phpfile ) ) {
+						$filename      = tc_filename( $php_key );
+						$grep          = tc_grep( $hook, $php_key );
 						$this->error[] = sprintf(
 							'<span class="tc-lead tc-required">%s</span>: %s',
 							__( 'REQUIRED', 'theme-check' ),


### PR DESCRIPTION
Fixes https://github.com/WordPress/theme-check/issues/383

Adds `add_role` to the list of forbidden functions.

It does a few more things...
- Removes the requirement that prevented removal of emojis.
- Displays the file name and line number. This meant adding an additional `foreach` but I think the benefit of displaying the line numbers is bigger.
- Updates the wording in the error messages, to help those who are not familiar with the "plugin-territory" terminology.
- Removes the add_shortcode check, and adds `add_shortcode` to the list of forbidden functions. It was unclear why this was a separate check.


### How to test
Please test this with real theme examples.

For a quick test, include the following in your test theme:

```
register_post_type();
register_taxonomy();
register_block_type();
add_role();
add_shortcode();
remove_action( 'wp_head', 'wp_generator' );
remove_action( 'wp_head', 'feed_links' );
remove_action( 'wp_head', 'feed_links_extra' );
remove_action( 'wp_head', 'wp_resource_hints' );
remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head' );
remove_action( 'wp_head', 'wp_shortlink_wp_head' );
remove_action( 'wp_head', '_admin_bar_bump_cb' );
remove_action( 'wp_head', 'rsd_link' );
remove_action( 'wp_head', 'rest_output_link_wp_head' );
remove_action( 'wp_head', 'wp_oembed_add_discovery_links' );
remove_action( 'wp_head', 'wp_oembed_add_host_js' );
remove_action( 'wp_head', 'rel_canonical' );
remove_action( 'template_redirect', 'rest_output_link_header' );
remove_action( 'template_redirect', 'wp_shortlink_header' );
remove_action( 'template_redirect', 'redirect_canonical' );

```