### PR TITLE
Update TextDomain_Check

### DIFF
--- a/checks/class-textdomain-check.php
+++ b/checks/class-textdomain-check.php
@@ -115,10 +115,10 @@ class TextDomain_Check implements themecheck {
 							if ( ! isset( $this->rules[ $func ][ $args_count ] ) ) {
 								$filename = tc_filename( $php_key );
 								// Avoid a warning when too many arguments are in a function, cause a fail case.
-								$new_args      = $args;
-								$new_args[]    = $text;
-								$error         = $new_args['0'];
-								$grep          = tc_grep( $error, $php_key );
+								$new_args   = $args;
+								$new_args[] = $text;
+								$error      = $new_args['0'];
+								$grep       = tc_grep( $error, $php_key );
 
 								$this->error[] = sprintf(
 									'<span class="tc-lead tc-warning">%s</span>: %s',
@@ -157,8 +157,8 @@ class TextDomain_Check implements themecheck {
 						$error = implode( ', ', $args );
 
 						if ( ! $found_domain && ! empty( $error ) ) {
-							$filename      = tc_filename( $php_key );
-							$grep          = tc_grep( $error, $php_key );
+							$filename = tc_filename( $php_key );
+							$grep     = tc_grep( $error, $php_key );
 
 							$this->error[] = sprintf(
 								'<span class="tc-lead tc-warning">%s</span>: %s',
@@ -172,7 +172,7 @@ class TextDomain_Check implements themecheck {
 								)
 							);
 						}
-						
+
 						$in_func      = false;
 						$func         = '';
 						$args_started = false;

--- a/checks/class-textdomain-check.php
+++ b/checks/class-textdomain-check.php
@@ -117,14 +117,18 @@ class TextDomain_Check implements themecheck {
 								// Avoid a warning when too many arguments are in a function, cause a fail case.
 								$new_args      = $args;
 								$new_args[]    = $text;
+								$error         = $new_args['0'];
+								$grep          = tc_grep( $error, $php_key );
+
 								$this->error[] = sprintf(
 									'<span class="tc-lead tc-warning">%s</span>: %s',
 									__( 'WARNING', 'theme-check' ),
 									sprintf(
-										__( 'Found a translation function that has an incorrect number of arguments in the file %1$s. Function %2$s, with the arguments %3$s', 'theme-check' ),
+										__( 'Found a translation function that has an incorrect number of arguments in the file %1$s. Function %2$s, with the arguments %3$s. %4$s', 'theme-check' ),
 										$filename,
 										'<strong>' . $func . '</strong>',
-										'<strong>' . implode( ', ', $new_args ) . '</strong>'
+										'<strong>' . implode( ', ', $new_args ) . '</strong>',
+										$grep
 									)
 								);
 							} elseif ( $this->rules[ $func ][ $args_count ] == 'domain' ) {
@@ -150,19 +154,25 @@ class TextDomain_Check implements themecheck {
 				} elseif ( ')' == $token ) {
 					--$parens_balance;
 					if ( $in_func && 0 == $parens_balance ) {
-						if ( ! $found_domain ) {
+						$error = implode( ', ', $args );
+
+						if ( ! $found_domain && ! empty( $error ) ) {
 							$filename      = tc_filename( $php_key );
+							$grep          = tc_grep( $error, $php_key );
+
 							$this->error[] = sprintf(
 								'<span class="tc-lead tc-warning">%s</span>: %s',
 								__( 'WARNING', 'theme-check' ),
 								sprintf(
-									__( 'Found a translation function that is missing a text-domain in the file %1$s. Function %2$s, with the arguments %3$s', 'theme-check' ),
+									__( 'Found a translation function that is missing a text-domain in the file %1$s. Function %2$s, with the arguments %3$s. %4$s', 'theme-check' ),
 									$filename,
 									'<strong>' . $func . '</strong>',
-									'<strong>' . implode( ', ', $args ) . '</strong>'
+									'<strong>' . $error . '</strong>',
+									$grep
 								)
 							);
 						}
+						
 						$in_func      = false;
 						$func         = '';
 						$args_started = false;

--- a/checks/class-textdomain-check.php
+++ b/checks/class-textdomain-check.php
@@ -119,6 +119,13 @@ class TextDomain_Check implements themecheck {
 								$new_args[] = $text;
 								$error      = $new_args['0'];
 								$grep       = tc_grep( $error, $php_key );
+								$lines      = explode( 'Line', $grep );
+
+								foreach ( $lines as $line ) {
+									if ( strpos( $line, $func ) !== false && strpos( $line, $error ) !== false ) {
+										$grep = "<pre class='tc-grep'>" . __( 'Line ', 'theme-check' ) . $line . '</pre>';
+									}
+								}
 
 								$this->error[] = sprintf(
 									'<span class="tc-lead tc-warning">%s</span>: %s',
@@ -159,6 +166,12 @@ class TextDomain_Check implements themecheck {
 						if ( ! $found_domain && ! empty( $error ) ) {
 							$filename = tc_filename( $php_key );
 							$grep     = tc_grep( $error, $php_key );
+							$lines    = explode( 'Line', $grep );
+							foreach ( $lines as $line ) {
+								if ( strpos( $line, $func ) !== false && strpos( $line, $error ) !== false ) {
+									$grep = "<pre class='tc-grep'>" . __( 'Line ', 'theme-check' ) . $line . '</pre>';
+								}
+							}
 
 							$this->error[] = sprintf(
 								'<span class="tc-lead tc-warning">%s</span>: %s',
@@ -191,7 +204,7 @@ class TextDomain_Check implements themecheck {
 			$correct_domain = sanitize_title_with_dashes( $this->name );
 			if ( $this->slug != $correct_domain ) {
 				$this->error[] = sprintf(
-					'<span class="tc-lead tc-warning">%s</span> %s %s',
+					'<span class="tc-lead tc-warning">%s</span>: %s %s',
 					__( 'WARNING', 'theme-check' ),
 					sprintf(
 						__( "Your theme appears to be in the wrong directory for the theme name. The directory name must match the slug of the theme. This theme's correct slug and text-domain is %s.", 'theme-check' ),
@@ -201,7 +214,7 @@ class TextDomain_Check implements themecheck {
 				);
 			} elseif ( ! in_array( $correct_domain, $domains ) ) {
 				$this->error[] = sprintf(
-					'<span class="tc-lead tc-required">%s</span> %s %s',
+					'<span class="tc-lead tc-required">%s</span>: %s %s',
 					__( 'REQUIRED', 'theme-check' ),
 					sprintf(
 						__( "This theme text domain does not match the theme's slug. The text domain used: %s", 'theme-check' ),
@@ -218,7 +231,7 @@ class TextDomain_Check implements themecheck {
 
 		if ( $domainscount > 1 ) {
 			$this->error[] = sprintf(
-				'<span class="tc-lead tc-warning">%s</span> %s %s',
+				'<span class="tc-lead tc-warning">%s</span>: %s %s',
 				__( 'WARNING', 'theme-check' ),
 				__( 'More than one text-domain is being used in this theme. This means the theme will not be compatible with WordPress.org language packs.', 'theme-check' ),
 				sprintf(
@@ -228,7 +241,7 @@ class TextDomain_Check implements themecheck {
 			);
 		} else {
 			$this->error[] = sprintf(
-				'<span class="tc-lead tc-info">%s</span> %s %s',
+				'<span class="tc-lead tc-info">%s</span>: %s %s',
 				__( 'INFO', 'theme-check' ),
 				__( "Only one text-domain is being used in this theme. Make sure it matches the theme's slug correctly so that the theme will be compatible with WordPress.org language packs.", 'theme-check' ),
 				sprintf(

--- a/checks/class-textdomain-check.php
+++ b/checks/class-textdomain-check.php
@@ -21,14 +21,14 @@ class TextDomain_Check implements themecheck {
 	 *
 	 * @var string $name
 	 */
-	protected $name     = '';
+	protected $name = '';
 
 	/**
 	 * Theme slug
 	 *
 	 * @var string $slug
 	 */
-	protected $slug     = '';
+	protected $slug = '';
 
 	protected $is_wporg = false;
 
@@ -88,13 +88,13 @@ class TextDomain_Check implements themecheck {
 			return true;
 		}
 
-		$funcs = array_keys( $this->rules );
+		$funcs   = array_keys( $this->rules );
 		$domains = array();
 
 		foreach ( $php_files as $php_key => $phpfile ) {
 			$error = '';
-			// tokenize the file
-			$tokens = token_get_all( $phpfile );
+			// Tokenize the file.
+			$tokens         = token_get_all( $phpfile );
 			$in_func        = false;
 			$args_started   = false;
 			$parens_balance = 0;

--- a/checks/class-textdomain-check.php
+++ b/checks/class-textdomain-check.php
@@ -113,7 +113,7 @@ class TextDomain_Check implements themecheck {
 					} elseif ( T_CONSTANT_ENCAPSED_STRING == $id ) {
 						if ( $in_func && $args_started ) {
 							if ( ! isset( $this->rules[ $func ][ $args_count ] ) ) {
-								$filename      = tc_filename( $php_key );
+								$filename = tc_filename( $php_key );
 								// Avoid a warning when too many arguments are in a function, cause a fail case.
 								$new_args      = $args;
 								$new_args[]    = $text;
@@ -128,7 +128,7 @@ class TextDomain_Check implements themecheck {
 									)
 								);
 							} elseif ( $this->rules[ $func ][ $args_count ] == 'domain' ) {
-								//Sstrip quotes from the domain, avoids 'domain' and "domain" not being recognized as the same
+								// Strip quotes from the domain, avoids 'domain' and "domain" not being recognized as the same
 								$text         = str_replace( array( '"', "'" ), '', $text );
 								$domains[]    = $text;
 								$found_domain = true;


### PR DESCRIPTION
This PR:
1. Renames the file for the TextDomain_Check to follow the same format as the other files.
2. Updates the error messages to show the line number where the error occurred. This is something that have been requested by theme authors repeatedly.

**How to test:**
In your test theme, include any or all of the translation functions in the rules [array](https://github.com/WordPress/theme-check/pull/389/files#diff-9ddc6ba26ee2fb72c2757311deb8fc4fdd8fca4bac4de73a0975254c7063ef1eR36),
but without text domain or with an invalid amount of parameters.
For example, '[_n](https://developer.wordpress.org/reference/functions/_n/)' expects 3 or 4 parameters, and to test it, you would add only one or two.

**Known issues:**
The check is **very** slow.  
This PR should not be merged until it's fast enough and any timeout issues have been solved.