### PR TITLE
Add a warning for large image sizes

### DIFF
--- a/checks/class-image-size-check.php
+++ b/checks/class-image-size-check.php
@@ -28,7 +28,7 @@ class Image_Size_Check implements themecheck {
 		checkcount();
 
 		foreach ( $other_files as $other_key => $otherfile ) {
-			/* 
+			/*
 			* Check if the file is an image.
 			* Silence read error if the file is too small. @see https://www.php.net/manual/en/function.exif-imagetype.php#79283.
 			*/

--- a/checks/class-image-size-check.php
+++ b/checks/class-image-size-check.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Check if the image sizes are larger than necessary
+ *
+ * @package Theme Check
+ */
+
+/**
+ * Check if the image sizes are larger than necessary
+ */
+class Image_Size_Check implements themecheck {
+	/**
+	 * Error messages, warnings and info notices.
+	 *
+	 * @var array $error
+	 */
+	protected $error = array();
+
+	/**
+	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
+	 *
+	 * @param array $php_files File paths and content for PHP files.
+	 * @param array $css_files File paths and content for CSS files.
+	 * @param array $other_files Folder names, file paths and content for other files.
+	 */
+	public function check( $php_files, $css_files, $other_files ) {
+
+		checkcount();
+
+		foreach ( $other_files as $other_key => $otherfile ) {
+			// Check if the file is an image.
+			if ( exif_imagetype( $other_key ) !== false ) {
+				$image = filesize( $other_key );
+				// Convert image size to KB.
+				$image_size = round( $image / 1024 );
+				//Check if the file is larger than 500 KB.
+				if ( $image_size > 500 ) {
+					$this->error[] = sprintf(
+						'<span class="tc-lead tc-warning">%s</span>: %s',
+						__( 'WARNING', 'theme-check' ),
+						sprintf(
+							/* translators: %1$s file name. %2$s file size. */
+							__( '%1$s is %2$s KB large. Large file sizes have a negative impact on website performance and loading time. Compress images before using them.', 'theme-check' ),
+							basename( $other_key ),
+							$image_size,
+						)
+					);
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Get error messages from the checks.
+	 *
+	 * @return array Error message.
+	 */
+	public function getError() {
+		return $this->error;
+	}
+}
+
+$themechecks[] = new Image_Size_Check();

--- a/checks/class-image-size-check.php
+++ b/checks/class-image-size-check.php
@@ -33,7 +33,7 @@ class Image_Size_Check implements themecheck {
 				$image = filesize( $other_key );
 				// Convert image size to KB.
 				$image_size = round( $image / 1024 );
-				//Check if the file is larger than 500 KB.
+				// Check if the file is larger than 500 KB.
 				if ( $image_size > 500 ) {
 					$this->error[] = sprintf(
 						'<span class="tc-lead tc-warning">%s</span>: %s',
@@ -42,7 +42,7 @@ class Image_Size_Check implements themecheck {
 							/* translators: %1$s file name. %2$s file size. */
 							__( '%1$s is %2$s KB large. Large file sizes have a negative impact on website performance and loading time. Compress images before using them.', 'theme-check' ),
 							basename( $other_key ),
-							$image_size,
+							$image_size
 						)
 					);
 				}

--- a/checks/class-image-size-check.php
+++ b/checks/class-image-size-check.php
@@ -28,8 +28,11 @@ class Image_Size_Check implements themecheck {
 		checkcount();
 
 		foreach ( $other_files as $other_key => $otherfile ) {
-			// Check if the file is an image.
-			if ( exif_imagetype( $other_key ) !== false ) {
+			/* 
+			* Check if the file is an image.
+			* Silence read error if the file is too small. @see https://www.php.net/manual/en/function.exif-imagetype.php#79283.
+			*/
+			if ( @wp_get_image_mime( $other_key ) !== false ) {
 				$image = filesize( $other_key );
 				// Convert image size to KB.
 				$image_size = round( $image / 1024 );


### PR DESCRIPTION
Fixes #395
Displays a warning if there are images that are larger than 500 KB.

### Screenshot:
![image](https://user-images.githubusercontent.com/7422055/132015788-2a0649c7-d61b-4b16-93c5-a719f77c9a94.png)

### How to test:
1. Run Theme Check on any theme with an image file larger than 500 KB.
2. See the warning

