### PR TITLE
Update the FSE theme folders to the new proposed structure

### DIFF
--- a/checkbase.php
+++ b/checkbase.php
@@ -351,7 +351,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 	}
 
 	// Check whether this is a FSE theme by searching for an index.html block template.
-	if ( ! in_array( 'block-templates/index.html', $other_filenames, true ) ) {
+	if ( ! in_array( 'block-templates/index.html', $other_filenames, true ) && ! in_array( 'templates/index.html', $other_filenames, true ) ) {
 		return false;
 	}
 

--- a/checks/class-fse-required-files-check.php
+++ b/checks/class-fse-required-files-check.php
@@ -37,16 +37,14 @@ class FSE_Required_Files_Check implements themecheck {
 			array_push( $filenames, tc_filename( $php_key ) );
 		}
 
-		$musthave = array(
-			'block-templates/index.html',
-			'theme.json',
-		);
+		if ( ! in_array( 'theme.json', $filenames ) ) {
+			$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Could not find the file theme.json in the theme.', 'theme-check' ), '<strong>theme.json</strong>' );
+			$ret           = false;
+		}
 
-		foreach ( $musthave as $file ) {
-			if ( ! in_array( $file, $filenames ) ) {
-				$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Could not find the file %s in the theme.', 'theme-check' ), '<strong>' . $file . '</strong>' );
-				$ret           = false;
-			}
+		if ( ! in_array( 'block-templates/index.html', $filenames ) && ! in_array( 'templates/index.html', $filenames ) ) {
+			$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'Could not find the index.html template in the theme.', 'theme-check' ), '<strong>index.html</strong>' );
+			$ret           = false;
 		}
 
 		return $ret;


### PR DESCRIPTION
FSE themes are changing folders in https://github.com/WordPress/gutenberg/pull/36647
This PR adapts theme check accordingly.
It should only be merged after the linked PR is merged.