### PR TITLE
check for plugin territory of registerBlockType

### DIFF
--- a/checks/class-plugin-territory-check.php
+++ b/checks/class-plugin-territory-check.php
@@ -35,6 +35,7 @@ class Plugin_Territory_Check implements themecheck {
 			'register_block_type',
 			'add_role',
 			'add_shortcode',
+			'registerBlockType',
 		);
 
 		// Hooks (actions & filters) that are required to be removed from the theme.


### PR DESCRIPTION
Add registerBlockType in plugin territory. This PR is created based on the comment of Justin. 
https://themes.trac.wordpress.org/ticket/114545
