### PR TITLE
Update check for index.php

### DIFF
--- a/checks/class-file-check.php
+++ b/checks/class-file-check.php
@@ -66,7 +66,11 @@ class File_Check implements themecheck {
 			'favicon\.ico'        => __( 'Favicon', 'theme-check' ),
 		);
 
-		$musthave = array( 'index.php', 'style.css', 'readme.txt' );
+		$musthave = array( 'style.css', 'readme.txt' );
+
+		if ( get_bloginfo( 'version' ) < '6.0' ) {
+			$musthave[] = 'index.php';
+		}
 
 		checkcount();
 

--- a/checks/class-file-check.php
+++ b/checks/class-file-check.php
@@ -68,10 +68,6 @@ class File_Check implements themecheck {
 
 		$musthave = array( 'style.css', 'readme.txt' );
 
-		if ( get_bloginfo( 'version' ) < '6.0' ) {
-			$musthave[] = 'index.php';
-		}
-
 		checkcount();
 
 		foreach ( $blocklist as $file => $reason ) {
@@ -111,6 +107,15 @@ class File_Check implements themecheck {
 				);
 				$ret           = false;
 			}
+		}
+
+		if ( ! in_array( 'index.php', $filenames ) && ! in_array( 'templates/index.html', $filenames ) {
+			$this->error[] = sprintf(
+				'<span class="tc-lead tc-required">%s</span>: %s',
+				__( 'REQUIRED', 'theme-check' ),
+				__( 'Theme must contain an index.php or templates/index.html file.', 'theme-check' ),
+			);
+			$ret           = false;
 		}
 
 		return $ret;

--- a/checks/class-file-check.php
+++ b/checks/class-file-check.php
@@ -109,11 +109,11 @@ class File_Check implements themecheck {
 			}
 		}
 
-		if ( ! in_array( 'index.php', $filenames ) && ! in_array( 'templates/index.html', $filenames ) {
+		if ( ! in_array( 'index.php', $filenames ) && ! in_array( 'templates/index.html', $filenames ) ) {
 			$this->error[] = sprintf(
 				'<span class="tc-lead tc-required">%s</span>: %s',
 				__( 'REQUIRED', 'theme-check' ),
-				__( 'Theme must contain an index.php or templates/index.html file.', 'theme-check' ),
+				__( 'Theme must contain an index.php or templates/index.html file.', 'theme-check' )
 			);
 			$ret           = false;
 		}


### PR DESCRIPTION
Addresses #422. This PR updates the theme check to check for both `index.php` or `templates/index.html`, since WordPress themes are no longer required to have a index.php file: https://core.trac.wordpress.org/changeset/52940 

_(Started this PR at WCEU Contributor Day, I haven't had a chance to test this yet!)_