### PR TITLE
Remove index php requirement

### DIFF
--- a/checks/class-file-check.php
+++ b/checks/class-file-check.php
@@ -68,13 +68,16 @@ class File_Check implements themecheck {
 
 		$musthave = array( 'index.php', 'style.css', 'readme.txt' );
 
-		$fse_find = array_filter( array_keys( $other_files ), function( $file_name ) {
-			if ( false !== stripos( $file_name, 'templates/index.html' ) || false !== stripos( $file_name, 'block-templates/index.html' ) ) {
-				return true;
-			}
+		$fse_find = array_filter(
+			array_keys( $other_files ),
+			function( $file_name ) {
+				if ( false !== stripos( $file_name, 'templates/index.html' ) || false !== stripos( $file_name, 'block-templates/index.html' ) ) {
+					return true;
+				}
 
-			return false;
-		} );
+				return false;
+			}
+		);
 
 		if ( ! empty( $fse_find ) ) {
 			$fse_not_needed = array_search( 'index.php', $musthave );

--- a/checks/class-file-check.php
+++ b/checks/class-file-check.php
@@ -66,7 +66,20 @@ class File_Check implements themecheck {
 			'favicon\.ico'        => __( 'Favicon', 'theme-check' ),
 		);
 
-		$musthave = array( 'style.css', 'readme.txt' );
+		$musthave = array( 'index.php', 'style.css', 'readme.txt' );
+
+		$fse_find = array_filter( array_keys( $other_files ), function( $file_name ) {
+			if ( false !== stripos( $file_name, 'templates/index.html' ) || false !== stripos( $file_name, 'block-templates/index.html' ) ) {
+				return true;
+			}
+
+			return false;
+		} );
+
+		if ( ! empty( $fse_find ) ) {
+			$fse_not_needed = array_search( 'index.php', $musthave );
+			unset( $musthave[ $fse_not_needed ] );
+		}
 
 		checkcount();
 

--- a/checks/class-file-check.php
+++ b/checks/class-file-check.php
@@ -66,7 +66,7 @@ class File_Check implements themecheck {
 			'favicon\.ico'        => __( 'Favicon', 'theme-check' ),
 		);
 
-		$musthave = array( 'index.php', 'style.css', 'readme.txt' );
+		$musthave = array( 'style.css', 'readme.txt' );
 
 		checkcount();
 

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
     "scripts": {
         "standards:check": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
         "standards:fix": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
This PR will remove the REQUIRED index.php file from block themes. From WordPress 6.0, index.php file is optional in Block themes. 