### PR TITLE
adding style-variations tag to the list of valid tags

### DIFF
--- a/checks/class-style-tags-check.php
+++ b/checks/class-style-tags-check.php
@@ -169,6 +169,7 @@ class Style_Tags_Check implements themecheck {
 			'post-formats',
 			'rtl-language-support',
 			'sticky-post',
+			'style-variations',
 			'template-editing',
 			'theme-options',
 			'threaded-comments',


### PR DESCRIPTION
## What?
Adding "style-variations" tag is missing from the valid theme tags.

Without this fix you get this warning on themes using that tag:
```
INFO Found wrong tag, remove style-variations from your style.css header.
```

## Why? 
The "style-variations" is valid feature tag documented here:
https://make.wordpress.org/themes/handbook/review/required/theme-tags/#features-tags

Fixes: #439