### PR TITLE
Update the full-site-editing tag check to work on WordPress.org/themes

### DIFF
--- a/checks/class-style-tags-check.php
+++ b/checks/class-style-tags-check.php
@@ -24,9 +24,17 @@ class Style_Tags_Check implements themecheck {
 	 */
 	protected $tags = array();
 
+	/**
+	 * The WP_Theme instance being checked.
+	 *
+	 * @var WP_Theme $wp_theme
+	 */
+	protected $wp_theme = false;
+
 	function set_context( $data ) {
 		if ( isset( $data['theme'] ) ) {
-			$this->tags = $data['theme']['Tags'];
+			$this->tags     = $data['theme']['Tags'];
+			$this->wp_theme = $data['theme'];
 		}
 	}
 
@@ -90,18 +98,22 @@ class Style_Tags_Check implements themecheck {
 					$subject_tags_count++;
 				}
 
-				if ( $tag === 'full-site-editing' ) {
+				if ( $tag === 'full-site-editing' && $this->wp_theme ) {
+					$theme_dir = $this->wp_theme->get_stylesheet_directory();
 
-					$theme_name = isset( $_POST['themename'] ) ? wp_unslash( $_POST['themename'] ) : get_stylesheet();
-					$root_dir   = get_theme_root( $theme_name );
-					$theme_dir  = "$root_dir/$theme_name";
-
-					if ( ! file_exists( $theme_dir . '/theme.json' ) || ( ! file_exists( $theme_dir . '/templates/index.html' ) && ! file_exists( $theme_dir . '/block-templates/index.html' ) ) ) {
+					// Check if the theme has all the required files.
+					if (
+						! isset( $other_files[ "{$theme_dir}/theme.json" ] ) ||
+						(
+							! isset( $other_files[ "{$theme_dir}/templates/index.html" ] ) &&
+							! isset( $other_files[ "{$theme_dir}/block-templates/index.html" ] )
+						)
+					) {
 						$this->error[] = sprintf(
 							'<span class="tc-lead tc-required">%s</span> %s',
 							__( 'REQUIRED', 'theme-check' ),
 							sprintf(
-								__( 'The tag %s is being  used, please remove it from your style.css header. It is only allowed for Block Theme. ', 'theme-check' ),
+								__( 'The tag %s is being used, please remove it from your style.css header. It is only allowed for Block Themes.', 'theme-check' ),
 								'<strong>' . $tag . '</strong>'
 							)
 						);


### PR DESCRIPTION
Currently the full-site-editing tag check is only working when Theme Check is run standalone, not when it's used automatically through the Theme Directory upload process.

This is because the check currently relies upon `$_POST` and `file_exists()` rather than using the files passed to the check.

This PR simply changes it from using `file_exists()` to using `isset()` - but with the additional complexity that the files passed are full paths, rather than relative, so the stylesheet directory is retrieved from `WP_Theme` instead.

This check may need to be extended to either
 a) Look at the parent theme too
 b) call a WP_Theme method to validate the files are present?

But this PR should make the fse error go away for block themes being uploaded.