### PR TITLE
adds skip links check for block themes

### DIFF
--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -33,17 +33,7 @@ class Skip_Links_Check implements themecheck {
 	function set_context( $data ) {
 		if ( isset( $data['theme'] ) ) {
 			$this->wp_theme = $data['theme'];
-			$theme_dir      = $this->wp_theme->get_stylesheet_directory();
-			// Check if the theme has all the required files.
-			if (
-				file_exists( $theme_dir . '/theme.json' ) ||
-				(
-					file_exists( $theme_dir . '/templates/index.html' ) &&
-					file_exists( $theme_dir . '/block-templates/index.html' )
-				)
-			) {
-				$this->is_block_theme = true;
-			}
+			$this->is_block_theme = wp_is_block_theme();
 		}
 	}
 

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -82,7 +82,7 @@ class Skip_Links_Check implements themecheck {
 				'<span class="tc-lead tc-required">%s</span> %s ',
 				__( 'REQUIRED', 'theme-check' ),
 				sprintf(
-					__( 'Skip links are missing from the following templates: %s Please make sure the templates have a <main> tag', 'theme-check' ),
+					__( 'Skip links are missing from the following templates: %s Please make sure the templates have a &lt;main&gt; tag', 'theme-check' ),
 					$info
 				)
 			);

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -49,31 +49,28 @@ class Skip_Links_Check implements themecheck {
 		$info                       = '';
 		$templates_without_main_tag = array();
 
-		$directory = 'templates'; // Path to the folder containing HTML files
-		$theme_dir = $this->wp_theme->get_stylesheet_directory();
+		foreach ( $other_files as $php_key => $file ) {
+			//if the file is a template, print the name of the file
+			if ( strpos( $php_key, 'templates/' ) !== false ) {
 
-		// Get all HTML files in the directory
-		$files = glob( $theme_dir . '/' . $directory . '/*.html' );
+				$file_name = tc_filename( $php_key );
+				$has_main_tag = strpos( $file, '<main' ) !== false;
 
-		foreach ( $files as $file ) {
-			$contents     = file_get_contents( $file );
-			$has_main_tag = strpos( $contents, '<main' ) !== false;
-			$file_name    = basename( $file );
-
-			if ( ! $has_main_tag ) {
-				$pattern_slugs = $this->template_has_patterns( $contents );
-				if ( $pattern_slugs ) {
-					foreach ( $pattern_slugs as $slug ) {
-						$has_main_tag = $this->pattern_has_tag( $slug );
-						if ( ! $has_main_tag ) {
-							if ( ! in_array( $file_name, $templates_without_main_tag ) ) {
-								$templates_without_main_tag[] = $file_name;
+				if ( ! $has_main_tag ) {
+					$pattern_slugs = $this->template_has_patterns( $file );
+					if ( $pattern_slugs ) {
+						foreach ( $pattern_slugs as $slug ) {
+							$has_main_tag = $this->pattern_has_tag( $slug );
+							if ( ! $has_main_tag ) {
+								if ( ! in_array( $file_name, $templates_without_main_tag ) ) {
+									$templates_without_main_tag[] = $file_name;
+								}
 							}
 						}
-					}
-				} else {
-					if ( ! in_array( $file_name, $templates_without_main_tag ) ) {
-						$templates_without_main_tag[] = $file_name;
+					} else {
+						if ( ! in_array( $file_name, $templates_without_main_tag ) ) {
+							$templates_without_main_tag[] = $file_name;
+						}
 					}
 				}
 			}

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Check if skip links are present on block themes
+ *
+ * @package Theme Check
+ */
+
+/**
+ * Check if skip links are present on block themes
+ */
+class Skip_Links_Check implements themecheck {
+	/**
+	 * Error messages, warnings and info notices.
+	 *
+	 * @var array $error
+	 */
+	protected $error = array();
+
+	/**
+	 * Returns true if the theme is a block theme.
+	 *
+	 * @var array $is_block_theme
+	 */
+	protected $is_block_theme = false;
+
+	/**
+	 * The WP_Theme instance being checked.
+	 *
+	 * @var WP_Theme $wp_theme
+	 */
+	protected $wp_theme = false;
+
+	function set_context( $data ) {
+		if ( isset( $data['theme'] ) ) {
+			$this->wp_theme = $data['theme'];
+			$theme_dir = $this->wp_theme->get_stylesheet_directory();
+			// Check if the theme has all the required files.
+			if (
+				file_exists($theme_dir.'/theme.json') ||
+				(
+					file_exists($theme_dir.'/templates/index.html') &&
+					file_exists($theme_dir.'/block-templates/index.html')
+				)
+			) {
+				$this->is_block_theme = true;
+			}
+		}
+	}
+
+	/**
+	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
+	 *
+	 * @param array $php_files File paths and content for PHP files.
+	 * @param array $css_files File paths and content for CSS files.
+	 * @param array $other_files Folder names, file paths and content for other files.
+	 */
+	public function check( $php_files, $css_files, $other_files ) {
+
+
+		$info = '';
+		$templates_without_main_tag = [];
+
+		$directory = 'templates'; // Path to the folder containing HTML files
+		$theme_dir = $this->wp_theme->get_stylesheet_directory();
+
+		// Get all HTML files in the directory
+		$files = glob($theme_dir . '/' . $directory . '/*.html');
+		
+		foreach ($files as $file) {
+			$contents = file_get_contents($file);
+			$hasMainTag = strpos($contents, '<main') !== false;
+			$fileName = basename($file);
+
+			// Print the result
+			if(!$hasMainTag) {
+				$templates_without_main_tag[] = $fileName;
+			}
+			//TODO: check on nested patterns!!
+		}
+
+		$info = implode(', ', $templates_without_main_tag);
+
+		if($info !== '') {
+			$this->error[] = sprintf(
+				'<span class="tc-lead tc-required">%s</span> %s ',
+				__( 'REQUIRED', 'theme-check' ),
+				sprintf(
+					__( 'Skip links are missing from the following templates: ' . $info . '. Please make sure the templates have a <main> tag', 'theme-check' )
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get error messages from the checks.
+	 *
+	 * @return array Error message.
+	 */
+	public function getError() {
+		return $this->error;
+	}
+}
+
+$themechecks[] = new Skip_Links_Check();

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -66,11 +66,15 @@ class Skip_Links_Check implements themecheck {
 					foreach ( $pattern_slugs as $slug ) {
 						$has_main_tag = $this->pattern_has_tag( $slug );
 						if ( ! $has_main_tag ) {
-							$templates_without_main_tag[] = $file_name;
+							if ( ! in_array( $file_name, $templates_without_main_tag ) ) {
+								$templates_without_main_tag[] = $file_name;
+							}
 						}
 					}
 				} else {
-					$templates_without_main_tag[] = $file_name;
+					if ( ! in_array( $file_name, $templates_without_main_tag ) ) {
+						$templates_without_main_tag[] = $file_name;
+					}
 				}
 			}
 		}

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -82,7 +82,7 @@ class Skip_Links_Check implements themecheck {
 				'<span class="tc-lead tc-required">%s</span> %s ',
 				__( 'REQUIRED', 'theme-check' ),
 				sprintf(
-					__( 'Skip links are missing from the following templates: %s Please make sure the templates have a &lt;main&gt; tag', 'theme-check' ),
+					__( 'Skip links are missing from the following templates: %s Please make sure the templates have a &lt;main&gt; tag.', 'theme-check' ),
 					$info
 				)
 			);

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -33,13 +33,13 @@ class Skip_Links_Check implements themecheck {
 	function set_context( $data ) {
 		if ( isset( $data['theme'] ) ) {
 			$this->wp_theme = $data['theme'];
-			$theme_dir = $this->wp_theme->get_stylesheet_directory();
+			$theme_dir      = $this->wp_theme->get_stylesheet_directory();
 			// Check if the theme has all the required files.
 			if (
-				file_exists($theme_dir.'/theme.json') ||
+				file_exists( $theme_dir . '/theme.json' ) ||
 				(
-					file_exists($theme_dir.'/templates/index.html') &&
-					file_exists($theme_dir.'/block-templates/index.html')
+					file_exists( $theme_dir . '/templates/index.html' ) &&
+					file_exists( $theme_dir . '/block-templates/index.html' )
 				)
 			) {
 				$this->is_block_theme = true;
@@ -56,31 +56,30 @@ class Skip_Links_Check implements themecheck {
 	 */
 	public function check( $php_files, $css_files, $other_files ) {
 
-
-		$info = '';
-		$templates_without_main_tag = [];
+		$info                       = '';
+		$templates_without_main_tag = array();
 
 		$directory = 'templates'; // Path to the folder containing HTML files
 		$theme_dir = $this->wp_theme->get_stylesheet_directory();
 
 		// Get all HTML files in the directory
-		$files = glob($theme_dir . '/' . $directory . '/*.html');
-		
-		foreach ($files as $file) {
-			$contents = file_get_contents($file);
-			$hasMainTag = strpos($contents, '<main') !== false;
-			$fileName = basename($file);
+		$files = glob( $theme_dir . '/' . $directory . '/*.html' );
+
+		foreach ( $files as $file ) {
+			$contents   = file_get_contents( $file );
+			$hasMainTag = strpos( $contents, '<main' ) !== false;
+			$fileName   = basename( $file );
 
 			// Print the result
-			if(!$hasMainTag) {
+			if ( ! $hasMainTag ) {
 				$templates_without_main_tag[] = $fileName;
 			}
-			//TODO: check on nested patterns!!
+			// TODO: check on nested patterns!!
 		}
 
-		$info = implode(', ', $templates_without_main_tag);
+		$info = implode( ', ', $templates_without_main_tag );
 
-		if($info !== '') {
+		if ( $info !== '' ) {
 			$this->error[] = sprintf(
 				'<span class="tc-lead tc-required">%s</span> %s ',
 				__( 'REQUIRED', 'theme-check' ),

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -86,6 +86,7 @@ class Skip_Links_Check implements themecheck {
 					$info
 				)
 			);
+			return false;
 		}
 
 		return true;

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -32,7 +32,7 @@ class Skip_Links_Check implements themecheck {
 
 	function set_context( $data ) {
 		if ( isset( $data['theme'] ) ) {
-			$this->wp_theme = $data['theme'];
+			$this->wp_theme       = $data['theme'];
 			$this->is_block_theme = wp_is_block_theme();
 		}
 	}
@@ -122,6 +122,14 @@ class Skip_Links_Check implements themecheck {
 				$pattern  = '/\* Slug: ' . preg_quote( $slug, '/' ) . '\b/';
 				if ( preg_match( $pattern, $contents ) ) {
 					$has_tag = strpos( $contents, '<main' ) !== false;
+					if ( ! $has_tag ) {
+						$nested_patterns_slugs = $this->template_has_patterns( $contents );
+						if ( $nested_patterns_slugs ) {
+							foreach ( $nested_patterns_slugs as $slug ) {
+								$has_tag = $this->pattern_has_tag( $slug );
+							}
+						}
+					}
 				}
 			}
 		}

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -66,21 +66,21 @@ class Skip_Links_Check implements themecheck {
 		$files = glob( $theme_dir . '/' . $directory . '/*.html' );
 
 		foreach ( $files as $file ) {
-			$contents   = file_get_contents( $file );
-			$hasMainTag = strpos( $contents, '<main' ) !== false;
-			$fileName   = basename( $file );
+			$contents     = file_get_contents( $file );
+			$has_main_tag = strpos( $contents, '<main' ) !== false;
+			$file_name    = basename( $file );
 
-			if ( ! $hasMainTag ) {
-				$pattern_slugs = $this->template_has_patterns($contents);
-				if( $pattern_slugs ) {
-					foreach($pattern_slugs as $slug){
-						$hasMainTag = $this->pattern_has_tag($slug);
-						if ( ! $hasMainTag ) {
-							$templates_without_main_tag[] = $fileName;
+			if ( ! $has_main_tag ) {
+				$pattern_slugs = $this->template_has_patterns( $contents );
+				if ( $pattern_slugs ) {
+					foreach ( $pattern_slugs as $slug ) {
+						$has_main_tag = $this->pattern_has_tag( $slug );
+						if ( ! $has_main_tag ) {
+							$templates_without_main_tag[] = $file_name;
 						}
 					}
-				}else {
-					$templates_without_main_tag[] = $fileName;
+				} else {
+					$templates_without_main_tag[] = $file_name;
 				}
 			}
 		}
@@ -92,7 +92,8 @@ class Skip_Links_Check implements themecheck {
 				'<span class="tc-lead tc-required">%s</span> %s ',
 				__( 'REQUIRED', 'theme-check' ),
 				sprintf(
-					__( 'Skip links are missing from the following templates: ' . $info . '. Please make sure the templates have a <main> tag', 'theme-check' )
+					__( 'Skip links are missing from the following templates: %s Please make sure the templates have a <main> tag', 'theme-check' ),
+					$info
 				)
 			);
 		}
@@ -100,9 +101,9 @@ class Skip_Links_Check implements themecheck {
 		return true;
 	}
 
-	function template_has_patterns($contents) {
+	function template_has_patterns( $contents ) {
 		$pattern = '/<!-- wp:pattern \{"slug":"([^"]+)"\} \/-->/';
-		if (preg_match_all($pattern, $contents, $matches)) {
+		if ( preg_match_all( $pattern, $contents, $matches ) ) {
 			$slugs = $matches[1];
 			return $slugs;
 		} else {
@@ -110,32 +111,31 @@ class Skip_Links_Check implements themecheck {
 		}
 	}
 
-	function pattern_has_tag($slug){
-		$directory = 'patterns'; 		
+	function pattern_has_tag( $slug ) {
+		$directory = 'patterns';
 		$theme_dir = $this->wp_theme->get_stylesheet_directory();
 
-		if(! is_dir($theme_dir . '/' . $directory)){
-			$directory = 'block-patterns'; 		
+		if ( ! is_dir( $theme_dir . '/' . $directory ) ) {
+			$directory = 'block-patterns';
 		}
-		if(! is_dir($theme_dir . '/' . $directory)){
-			return false;	
+		if ( ! is_dir( $theme_dir . '/' . $directory ) ) {
+			return false;
 		}
 
 		$files = glob( $theme_dir . '/' . $directory . '/*.php' );
 
 		$has_tag = false;
-	
-		foreach ($files as $file) {
-			if (is_file($file)) {
-				$contents = file_get_contents($file);
-				$pattern = '/\* Slug: ' . preg_quote($slug, '/') . '\b/';
-				if (preg_match($pattern, $contents)) {
+
+		foreach ( $files as $file ) {
+			if ( is_file( $file ) ) {
+				$contents = file_get_contents( $file );
+				$pattern  = '/\* Slug: ' . preg_quote( $slug, '/' ) . '\b/';
+				if ( preg_match( $pattern, $contents ) ) {
 					$has_tag = strpos( $contents, '<main' ) !== false;
-					print_r($has_tag);
 				}
 			}
 		}
-	
+
 		return $has_tag;
 	}
 

--- a/checks/class-skip-links.php
+++ b/checks/class-skip-links.php
@@ -50,10 +50,10 @@ class Skip_Links_Check implements themecheck {
 		$templates_without_main_tag = array();
 
 		foreach ( $other_files as $php_key => $file ) {
-			//if the file is a template, print the name of the file
+			// if the file is a template, print the name of the file
 			if ( strpos( $php_key, 'templates/' ) !== false ) {
 
-				$file_name = tc_filename( $php_key );
+				$file_name    = tc_filename( $php_key );
 				$has_main_tag = strpos( $file, '<main' ) !== false;
 
 				if ( ! $has_main_tag ) {


### PR DESCRIPTION
This PR adds a check only for block themes to see if templates have a main tag present. If they don't they will be missing the skip links from said template.

I need to check when a template is made out of a pattern and the main tag will be inside the pattern instead of the template file