### PR TITLE
Update /theme-check/checks/class-title-check.php, replace reg pattern…

### DIFF
--- a/checks/class-title-check.php
+++ b/checks/class-title-check.php
@@ -50,7 +50,7 @@ class Title_Check implements themecheck {
 			}
 
 			// Look for anything that looks like <svg>...</svg> and exclude it (inline svg's have titles too).
-			$file_content = preg_replace( '/<svg.*>.*<\/svg>/s', '', $file_content );
+			$file_content = preg_replace( '/<svg.*>.*<\/svg>/i', '', $file_content );
 
 			// Look for <title> and </title> tags.
 			checkcount();


### PR DESCRIPTION
… modifier (/s) with (/i)

File: /theme-check/checks/class-title-check.php 

Error:
Around line 57 of the file, an attempt is made to trigger an error if any file uses a variation of the word "title" in an unexpected way. SVG files are intended to be exempted from this check. However, due to the use of the "/s" modifier in the regular expression on line 53, the content of any file containing SVG tags is treated as a single line, effectively nullifying the file content. 
This causes an error on line 57, where the strpos() function does not accept null as a parameter. 

Fix:
The fix replaces the "/s" modifier with "/i" in the regular expression. The "/i" modifier makes the pattern case-insensitive, which is more appropriate for this check.

Further information:
Please see the full list of allowed modifiers for your review: https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
