### PR TITLE
Disable Block_Patterns_Check for block themes

### DIFF
--- a/checkbase.php
+++ b/checkbase.php
@@ -378,6 +378,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 			|| $check instanceof Theme_Support_Title_Tag_Check
 			|| $check instanceof Screen_Reader_Text_Check
 			|| $check instanceof Include_Check
+			|| $check instanceof Block_Patterns_Check
 		) {
 			unset( $themechecks[ $key ] );
 		}


### PR DESCRIPTION
## What?
Disable Block_Patterns_Check for block themes
https://github.com/matiasbenedetto/theme-check/blob/2052c6884f049589554be54c3b2e594aee07b4ce/checks/class-block-patterns-check.php

When checking block themes the messages below won't be printed.

## Why?
This check prints these messages on block themes which doesn't seems to be needed:
```
RECOMMENDED
No reference to register_block_pattern was found in the theme. Theme authors are encouraged to implement custom block patterns as a transition to block themes.

RECOMMENDED
No reference to register_block_style was found in the theme. Theme authors are encouraged to implement new block styles as a transition to block themes.
```