### PR TITLE
Non_GPL_Check check returns false when it fails

### DIFF
--- a/checks/class-non-gpl-check.php
+++ b/checks/class-non-gpl-check.php
@@ -56,6 +56,8 @@ class Non_GPL_Check implements themecheck {
 					),
 					'<a href="' . esc_url( $link_url ) . '" target="_blank">' . __( 'View license (opens in a new window).', 'theme-check' ) . '</a>'
 				);
+				// Return false to indicate that the check failed with a REQUIRED change message.
+				$ret = false;
 			}
 		}
 


### PR DESCRIPTION
## What?

Non_GPL_Check check returns false when it fails

## Why?
Fixes: https://github.com/WordPress/theme-check/issues/465