### PR TITLE
Print README examples as a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ On success, the command returns a formatted table of results from the theme chec
 | `format` | `table` or `json` | No | `table`
 
 #### Examples
-`wp theme-check run`
-`wp theme-check run twentytwentyfour`
-`wp theme-check run --format=json`
-`wp theme-check run twentytwentyfour --format=json`
+- `wp theme-check run`
+- `wp theme-check run twentytwentyfour`
+- `wp theme-check run --format=json`
+- `wp theme-check run twentytwentyfour --format=json`
 
 ## Contributors
 Otto42, pross, The theme review team


### PR DESCRIPTION
## What?
Print README examples as a list.

## Why?
To make them easier to read

## Screenshots

**Before:**
![Screenshot from 2024-09-26 09-58-38](https://github.com/user-attachments/assets/813903db-bc85-4c88-802a-0c4fce083aee)

**After:**
![Screenshot from 2024-09-26 09-59-06](https://github.com/user-attachments/assets/332848c0-fef3-46f5-b186-1fe56d8eb544)
