### PR TITLE
Check the number of h1 elements on block theme templates

### DIFF
--- a/checkbase.php
+++ b/checkbase.php
@@ -386,6 +386,7 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 
 	// Add FSE specific checks.
 	$themechecks[] = new FSE_Required_Files_Check();
+	$themechecks[] = new FSE_Templates_H1_Check();
 
 	return true;
 }

--- a/checks/class-fse-templates-h1-check.php
+++ b/checks/class-fse-templates-h1-check.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Checks that Full-Site Editing theme templates have 1 and only 1 h1 tag.
+ *
+ * @package Theme Check
+ */
+
+/**
+ * Class FSE_Templates_H1_Check
+ *
+ * Checks that Full-Site Editing theme templates have 1 and only 1 h1 tag.
+ *
+ * This check is not added to the global array of checks, because it doesn't apply to all themes.
+ */
+class FSE_Templates_H1_Check implements themecheck {
+	/**
+	 * Error messages, warnings and info notices.
+	 *
+	 * @var array $error
+	 */
+	protected $error = array();
+
+	/**
+	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
+	 *
+	 * @param array $php_files File paths and content for PHP files.
+	 * @param array $css_files File paths and content for CSS files.
+	 * @param array $other_files Folder names, file paths and content for other files.
+	 */
+	public function check( $php_files, $css_files, $other_files ) {
+
+		$ret = true;
+        $templates = get_block_templates();
+        $templates_with_multiple_h1_tags = array();
+        $templates_with_no_h1_tags = array();
+
+        foreach ($templates as $template) {
+            $blocks = parse_blocks( $template->content );
+            $h1_count = $this->count_h1_tags_recursively( $blocks );
+
+            if ( $h1_count > 1 ) {
+                $ret = false;
+                $templates_with_multiple_h1_tags[] = $template->slug;
+            }
+
+            if ( $h1_count === 0 ) {
+                $templates_with_no_h1_tags[] = $template->slug;
+            }
+        }
+
+        if ( ! empty( $templates_with_multiple_h1_tags ) ) {
+            $this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'The following templates have multiple h1 tags: %s', 'theme-check' ), '<strong>' . implode( ', ', $templates_with_multiple_h1_tags ) . '</strong>' );
+        }
+
+        if ( ! empty( $templates_with_no_h1_tags ) ) {
+            $this->error[] = sprintf( '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . __( 'The following templates have no h1 tags: %s', 'theme-check' ), '<strong>' . implode( ', ', $templates_with_no_h1_tags ) . '</strong>' );
+        }
+
+		return $ret;
+	}
+
+	/**
+	 * Recursively count h1 tags in blocks, including nested blocks.
+	 *
+	 * @param array $blocks Array of blocks to process.
+	 * @return int Number of h1 tags found.
+	 */
+	private function count_h1_tags_recursively( $blocks ) {
+		$h1_count = 0;
+		foreach ( $blocks as $block ) {
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$h1_count += $this->count_h1_tags_recursively( $block['innerBlocks'] );
+			} else {
+                if ( $block['blockName'] === 'core/heading' || $block['blockName'] === 'core/post-title' ){
+                    if ( isset( $block['attrs']['level'] ) && $block['attrs']['level'] === 1 ) {
+                        $h1_count++;
+                    }
+                }
+            }
+		}
+		return $h1_count;
+	}
+
+	/**
+	 * Get error messages from the checks.
+	 *
+	 * @return array Error message.
+	 */
+	public function getError() {
+		return $this->error;
+	}
+}

--- a/checks/class-fse-templates-h1-check.php
+++ b/checks/class-fse-templates-h1-check.php
@@ -39,7 +39,6 @@ class FSE_Templates_H1_Check implements themecheck {
 			$h1_count = $this->count_h1_tags_recursively( $blocks );
 
 			if ( $h1_count > 1 ) {
-				$ret                               = false;
 				$templates_with_multiple_h1_tags[] = $template->slug;
 			}
 
@@ -49,7 +48,7 @@ class FSE_Templates_H1_Check implements themecheck {
 		}
 
 		if ( ! empty( $templates_with_multiple_h1_tags ) ) {
-			$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'The following templates have multiple h1 tags: %s', 'theme-check' ), '<strong>' . implode( ', ', $templates_with_multiple_h1_tags ) . '</strong>' );
+			$this->error[] = sprintf( '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . __( 'The following templates have multiple h1 tags: %s', 'theme-check' ), '<strong>' . implode( ', ', $templates_with_multiple_h1_tags ) . '</strong>' );
 		}
 
 		if ( ! empty( $templates_with_no_h1_tags ) ) {

--- a/checks/class-fse-templates-h1-check.php
+++ b/checks/class-fse-templates-h1-check.php
@@ -29,32 +29,32 @@ class FSE_Templates_H1_Check implements themecheck {
 	 */
 	public function check( $php_files, $css_files, $other_files ) {
 
-		$ret = true;
-        $templates = get_block_templates();
-        $templates_with_multiple_h1_tags = array();
-        $templates_with_no_h1_tags = array();
+		$ret                             = true;
+		$templates                       = get_block_templates();
+		$templates_with_multiple_h1_tags = array();
+		$templates_with_no_h1_tags       = array();
 
-        foreach ($templates as $template) {
-            $blocks = parse_blocks( $template->content );
-            $h1_count = $this->count_h1_tags_recursively( $blocks );
+		foreach ( $templates as $template ) {
+			$blocks   = parse_blocks( $template->content );
+			$h1_count = $this->count_h1_tags_recursively( $blocks );
 
-            if ( $h1_count > 1 ) {
-                $ret = false;
-                $templates_with_multiple_h1_tags[] = $template->slug;
-            }
+			if ( $h1_count > 1 ) {
+				$ret                               = false;
+				$templates_with_multiple_h1_tags[] = $template->slug;
+			}
 
-            if ( $h1_count === 0 ) {
-                $templates_with_no_h1_tags[] = $template->slug;
-            }
-        }
+			if ( $h1_count === 0 ) {
+				$templates_with_no_h1_tags[] = $template->slug;
+			}
+		}
 
-        if ( ! empty( $templates_with_multiple_h1_tags ) ) {
-            $this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'The following templates have multiple h1 tags: %s', 'theme-check' ), '<strong>' . implode( ', ', $templates_with_multiple_h1_tags ) . '</strong>' );
-        }
+		if ( ! empty( $templates_with_multiple_h1_tags ) ) {
+			$this->error[] = sprintf( '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' . __( 'The following templates have multiple h1 tags: %s', 'theme-check' ), '<strong>' . implode( ', ', $templates_with_multiple_h1_tags ) . '</strong>' );
+		}
 
-        if ( ! empty( $templates_with_no_h1_tags ) ) {
-            $this->error[] = sprintf( '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . __( 'The following templates have no h1 tags: %s', 'theme-check' ), '<strong>' . implode( ', ', $templates_with_no_h1_tags ) . '</strong>' );
-        }
+		if ( ! empty( $templates_with_no_h1_tags ) ) {
+			$this->error[] = sprintf( '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' . __( 'The following templates have no h1 tags: %s', 'theme-check' ), '<strong>' . implode( ', ', $templates_with_no_h1_tags ) . '</strong>' );
+		}
 
 		return $ret;
 	}
@@ -71,12 +71,12 @@ class FSE_Templates_H1_Check implements themecheck {
 			if ( ! empty( $block['innerBlocks'] ) ) {
 				$h1_count += $this->count_h1_tags_recursively( $block['innerBlocks'] );
 			} else {
-                if ( $block['blockName'] === 'core/heading' || $block['blockName'] === 'core/post-title' ){
-                    if ( isset( $block['attrs']['level'] ) && $block['attrs']['level'] === 1 ) {
-                        $h1_count++;
-                    }
-                }
-            }
+				if ( $block['blockName'] === 'core/heading' || $block['blockName'] === 'core/post-title' ) {
+					if ( isset( $block['attrs']['level'] ) && $block['attrs']['level'] === 1 ) {
+						$h1_count++;
+					}
+				}
+			}
 		}
 		return $h1_count;
 	}


### PR DESCRIPTION
## What?
Check the number of h1 elements on each block theme template.
This check only runs when checking block themes.

**Results:**
- If one template has multiple `h1` tags, it outputs a REQUIRED change error.
- If a template has zero `h1` tags, it outputs a WARNING.
- If a template has only one `h1` tag, it outputs nothing.

## How
It iterates over each block of a template and looks for core/heading or core/post-title with level one to determine the number of h1 blocks that will be printed on a page.

## Why?
To help theme creators use one `h1` tag per template following accessibility recommendations like: https://www.a11yproject.com/posts/how-to-accessible-heading-structure/

## Screenshot

Results in wp-admin:
![image](https://github.com/user-attachments/assets/90635c8a-29f9-437b-adcb-f92818d3ac53)


Results in CLI:
![image](https://github.com/user-attachments/assets/034997b1-7941-4c27-a75d-b1746ded4824)


