### PR TITLE
fix (copyright) typo in license.txt filename

### DIFF
--- a/checks/class-copyright-notice-check.php
+++ b/checks/class-copyright-notice-check.php
@@ -42,7 +42,7 @@ class Copyright_Notice_Check implements themecheck {
 			if ( stripos( $path, $this->slug . '/readme.txt' ) ||
 				stripos( $path, $this->slug . '/readme.md' ) ||
 				stripos( $path, $this->slug . '/style.css' ) ||
-				stripos( $path, $this->slug . '/licence.txt' ) !== false ) {
+				stripos( $path, $this->slug . '/license.txt' ) !== false ) {
 				$content .= $contents;
 			}
 		}


### PR DESCRIPTION
fix little typo as referrend in issue 474 https://github.com/WordPress/theme-check/issues/474 