### PR TITLE
Title Check: Avoid Deprecated warnings when there's no file contents.

### DIFF
--- a/checks/class-title-check.php
+++ b/checks/class-title-check.php
@@ -31,7 +31,7 @@ class Title_Check implements themecheck {
 
 		foreach ( $php_files as $file_path => $file_content ) {
 
-			if ( empty( $file_content ) ) {
+			if ( ! is_string( $file_content ) || '' === $file_content ) {
 				continue;
 			}
 
@@ -53,6 +53,10 @@ class Title_Check implements themecheck {
 
 			// Look for anything that looks like <svg>...</svg> and exclude it (inline svg's have titles too).
 			$file_content = preg_replace( '/<svg.*>.*<\/svg>/s', '', $file_content );
+
+			if ( ! is_string( $file_content ) ) {
+				continue;
+			}
 
 			// Look for <title> and </title> tags.
 			checkcount();

--- a/checks/class-title-check.php
+++ b/checks/class-title-check.php
@@ -29,9 +29,11 @@ class Title_Check implements themecheck {
 	 */
 	public function check( $php_files, $css_files, $other_files ) {
 
-		$php = implode( ' ', $php_files );
-
 		foreach ( $php_files as $file_path => $file_content ) {
+
+			if ( empty( $file_content ) ) {
+				continue;
+			}
 
 			// Check whether there is a call to wp_title().
 			checkcount();


### PR DESCRIPTION
Not 100% sure how this is happening, but seems like a quick win to avoid unnecessary processing and break early.

```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in wp-content/plugins/theme-check/checks/class-title-check.php on line 57 
```