### PR TITLE
Add check for MACOSX

### DIFF
--- a/checks/class-directories-macosx-check.php
+++ b/checks/class-directories-macosx-check.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Check if Macosx directory is included
+ *
+ * @package Theme Check
+ */
+
+/**
+ * Check if Macosx directory is included.
+ *
+ * Check if Macosx directory is included. If it is, require it to be removed.
+ */
+class Directories_Macosx_Check implements themecheck {
+	/**
+	 * Error messages, warnings and info notices.
+	 *
+	 * @var array $error
+	 */
+	protected $error = array();
+
+	/**
+	 * Theme context.
+	 *
+	 * @var WP_Theme $theme
+	 */
+	protected $theme;
+
+	/**
+	 * Set check context.
+	 *
+	 * @param array $data Context data.
+	 */
+	function set_context( $data ) {
+		if ( isset( $data['theme'] ) ) {
+			$this->theme = $data['theme'];
+		}
+	}
+
+	/**
+	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
+	 *
+	 * @param array $php_files File paths and content for PHP files.
+	 * @param array $css_files File paths and content for CSS files.
+	 * @param array $other_files Folder names, file paths and content for other files.
+	 */
+	public function check( $php_files, $css_files, $other_files ) {
+
+		$excluded_directories = array(
+			'__MACOSX',
+		);
+
+		$ret = true;
+
+		$theme_dir   = $this->theme->get_stylesheet_directory();
+		$directories = scandir( $theme_dir );
+
+		if ( false === $directories ) {
+			return true;
+		}
+
+		foreach ( $directories as $dir ) {
+			checkcount();
+
+			if ( in_array( $dir, $excluded_directories, true ) ) {
+				$this->error[] = sprintf(
+					'<span class="tc-lead tc-required">%s</span>: %s',
+					__( 'REQUIRED', 'theme-check' ),
+					__( 'Please remove any extraneous directories like <strong>__MACOSX</strong> from the ZIP file before uploading it.', 'theme-check' )
+				);
+				$ret           = false;
+			}
+		}
+
+		return $ret;
+	}
+
+	/**
+	 * Get error messages from the checks.
+	 *
+	 * @return array Error message.
+	 */
+	public function getError() {
+		return $this->error;
+	}
+}
+
+$themechecks[] = new Directories_Macosx_Check();


### PR DESCRIPTION
Add a new check for the __MACOSX directory.
Level: Required (error).

Partial for https://github.com/WordPress/theme-check/issues/403

Replaces https://github.com/WordPress/theme-check/pull/414 because TeBenachi is not actively contributing right now.

The difference between the two PR's:
Checks the theme root folder of the chosen theme from the plugin settings, not the active theme.
Small adjustment to the error message text.

### Testing Instructions
You need at least two themes installed.

1. In the theme that is not active, add a new folder with the name __MACOSX
2. (Or install a theme that has been actually zipped on a Mac: I don't have a Mac, so I cheated)
3. Run the theme check on the theme with the folder, and confirm that the correct error message shows
4. Run the theme check on the theme without the folder and confirm that the error message does not show.
