### PR TITLE
Update the class-directories-check.php

### DIFF
--- a/checks/class-directories-check.php
+++ b/checks/class-directories-check.php
@@ -53,7 +53,7 @@ class Directories_Check implements themecheck {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-required">%s</span>: %s',
 					__( 'REQUIRED', 'theme-check' ),
-					__( 'Please remove any extraneous directories like <strong>.git</strong>, <strong>.svn</strong>, <strong>.hg</strong>, <strong>.bzr</strong> or <strong>__MACOSX</strong> from the ZIP file before uploading it.', 'theme-check' )
+					__( 'Please remove any extraneous directories like .git, .svn, .hg, .bzr or __MACOSX from the ZIP file before uploading it.', 'theme-check' )
 				);
 				$ret           = false;
 				break;

--- a/checks/class-directories-check.php
+++ b/checks/class-directories-check.php
@@ -55,7 +55,7 @@ class Directories_Check implements themecheck {
 					__( 'REQUIRED', 'theme-check' ),
 					__( 'Please remove any extraneous directories like <strong>.git</strong>, <strong>.svn</strong> or <strong>__MACOSX</strong> from the ZIP file before uploading it.', 'theme-check' )
 				);
-				$ret = false;
+				$ret           = false;
 				break;
 			}
 		}

--- a/checks/class-directories-check.php
+++ b/checks/class-directories-check.php
@@ -1,14 +1,15 @@
 <?php
 /**
- * Check if directories only intended for development are included
+ * Check if disallowed directories are included
  *
  * @package Theme Check
  */
 
 /**
- * Check if directories only intended for development are included.
+ * Check if disallowed directories are included.
  *
- * Check if directories only intended for development are included. If they are, require them to be removed.
+ * Checks each file path for disallowed directory names such as .git or __MACOSX.
+ * Empty disallowed directories will not be detected as they contain no files.
  */
 class Directories_Check implements themecheck {
 	/**
@@ -21,13 +22,14 @@ class Directories_Check implements themecheck {
 	/**
 	 * Check that return true for good/okay/acceptable, false for bad/not-okay/unacceptable.
 	 *
-	 * @param array $php_files File paths and content for PHP files.
-	 * @param array $css_files File paths and content for CSS files.
+	 * @param array $php_files   File paths and content for PHP files.
+	 * @param array $css_files   File paths and content for CSS files.
 	 * @param array $other_files Folder names, file paths and content for other files.
 	 */
 	public function check( $php_files, $css_files, $other_files ) {
 
 		$excluded_directories = array(
+			'__MACOSX',
 			'.git',
 			'.svn',
 			'.hg',
@@ -45,15 +47,16 @@ class Directories_Check implements themecheck {
 		foreach ( $all_filenames as $path ) {
 			checkcount();
 
-			$filename = basename( $path );
+			$path_segments = explode( '/', str_replace( '\\', '/', $path ) );
 
-			if ( in_array( $filename, $excluded_directories, true ) ) {
+			if ( array_intersect( $path_segments, $excluded_directories ) ) {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-required">%s</span>: %s',
 					__( 'REQUIRED', 'theme-check' ),
-					__( 'Please remove any extraneous directories like .git or .svn from the ZIP file before uploading it.', 'theme-check' )
+					__( 'Please remove any extraneous directories like <strong>.git</strong>, <strong>.svn</strong> or <strong>__MACOSX</strong> from the ZIP file before uploading it.', 'theme-check' )
 				);
-				$ret           = false;
+				$ret = false;
+				break;
 			}
 		}
 

--- a/checks/class-directories-check.php
+++ b/checks/class-directories-check.php
@@ -53,7 +53,7 @@ class Directories_Check implements themecheck {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-required">%s</span>: %s',
 					__( 'REQUIRED', 'theme-check' ),
-					__( 'Please remove any extraneous directories like <strong>.git</strong>, <strong>.svn</strong> or <strong>__MACOSX</strong> from the ZIP file before uploading it.', 'theme-check' )
+					__( 'Please remove any extraneous directories like <strong>.git</strong>, <strong>.svn</strong>, <strong>.hg</strong>, <strong>.bzr</strong> or <strong>__MACOSX</strong> from the ZIP file before uploading it.', 'theme-check' )
 				);
 				$ret           = false;
 				break;

--- a/checks/class-directories-check.php
+++ b/checks/class-directories-check.php
@@ -49,7 +49,8 @@ class Directories_Check implements themecheck {
 
 			$path_segments = explode( '/', str_replace( '\\', '/', $path ) );
 
-			if ( array_intersect( $path_segments, $excluded_directories ) ) {
+			$matched_directories = array_intersect( $path_segments, $excluded_directories );
+			if ( ! empty( $matched_directories ) ) {
 				$this->error[] = sprintf(
 					'<span class="tc-lead tc-required">%s</span>: %s',
 					__( 'REQUIRED', 'theme-check' ),


### PR DESCRIPTION
Closes https://github.com/WordPress/theme-check/issues/403
Replaces https://github.com/WordPress/theme-check/pull/414

Fixes a bug where disallowed directories were not detected because only the filename was checked, not the full path.
Adds __MACOSX to the list of directories.
Updates the error message.

**Does not detect empty folders**, it seems unlikely that empty folders would be included.
It is kind of backwards to check for files and then check what folder they are in... But we already have the list of files.
This is only one way to solve this, _but it is the smallest change._ I don't feel strongly for or against this versus a directory scan.

### Testing Instructions
You need at least two themes installed.

1. In one of the themes,  add a new folder with the name __MACOSX and add a file inside it (hello.txt or whatever). (Or install a theme that has been actually zipped on a Mac: I don't have a Mac, so I cheated)
2. Run the theme check on the theme with the folder, and confirm that the correct error message shows.
3. Run the theme check on the theme without the folder and confirm that the error message does not show.

Try some of the other folder names as well.

AI Usage: I argued back and forward with Copilot.