### PR TITLE
Skip classic theme checks when the block theme is in a subfolder

### DIFF
--- a/checkbase.php
+++ b/checkbase.php
@@ -351,7 +351,16 @@ function tc_adapt_checks_for_fse_themes( $php_files, $css_files, $other_files ) 
 	}
 
 	// Check whether this is a FSE theme by searching for an index.html block template.
-	if ( ! in_array( 'block-templates/index.html', $other_filenames, true ) && ! in_array( 'templates/index.html', $other_filenames, true ) ) {
+	// Match by suffix so themes nested under /themes/<dir>/<theme>/ are supported.
+	$has_fse_index_template = false;
+	foreach ( $other_filenames as $filename ) {
+		if ( preg_match( '!(^|/)(block-templates|templates)/index\.html$!i', $filename ) ) {
+			$has_fse_index_template = true;
+			break;
+		}
+	}
+
+	if ( ! $has_fse_index_template ) {
 		return false;
 	}
 


### PR DESCRIPTION
Closes https://github.com/WordPress/theme-check/issues/318


Testing instructions:
Move a block theme to a subfolder of the themes folder.
Run Theme Check on that theme.
Confirm that the classic checks like post thumbnail etc. are not showing in the result.
(Ssee the list of checks that are expected to be skipped: https://github.com/WordPress/theme-check/blob/master/checkbase.php#L359)

