### PR TITLE
Fix: Clear theme cache after adding extra_theme_headers

### DIFF
--- a/theme-check.php
+++ b/theme-check.php
@@ -44,6 +44,7 @@ class ThemeCheckMain {
 		}
 
 		add_filter( 'extra_theme_headers', array( $this, 'tc_add_headers' ) );
+		wp_clean_themes_cache( false );
 
 		include 'checkbase.php';
 		include 'main.php';


### PR DESCRIPTION


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #494 

<!-- In a few words, what is the PR actually doing? -->
This PR ensures that the "License" and "License URI" fields are correctly displayed in the Theme Info summary box when checking the currently active theme.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When Theme Check is run against the currently active theme, the "License" and "License URI" fields are missing from the visual summary box at the top of the WP Admin page. This occurs because WordPress caches the active theme's `WP_Theme` object early during initialization, long before Theme Check hooks into the `extra_theme_headers` filter to register these license fields.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR:
1. Adds a call to `wp_clean_themes_cache( false );` immediately after registering the `extra_theme_headers` filter in `theme-check.php`.
2. This busts the WordPress theme cache and forces `wp_get_theme()` to re-parse the active theme, successfully capturing the new headers.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Activate a theme on your site that has `License:` and `License URI:` defined in its `style.css`
2. Navigate to **Appearance > Theme Check**.
3. Select the currently active theme from the dropdown and click **Check it!**.
4. Look at the **Theme Info** summary box at the top of the results page.
5. Verify that both the `License` and `License URI` fields are now correctly displayed in the summary box.